### PR TITLE
Update 2022_02_01_235539_create_subscriptions_table.php

### DIFF
--- a/database/migrations/2022_02_01_235539_create_subscriptions_table.php
+++ b/database/migrations/2022_02_01_235539_create_subscriptions_table.php
@@ -17,7 +17,7 @@ return new class() extends Migration {
             $table->id();
             $table->foreignIdFor(\LucasDotVin\Soulbscription\Models\Plan::class);
             $table->timestamp('canceled_at')->nullable();
-            $table->timestamp('expired_at');
+            $table->timestamp('expired_at')->nullable();
             $table->timestamp('grace_days_ended_at')->nullable();
             $table->date('started_at');
             $table->timestamp('suppressed_at')->nullable();

--- a/src/Models/Concerns/HasSubscriptions.php
+++ b/src/Models/Concerns/HasSubscriptions.php
@@ -121,6 +121,13 @@ trait HasSubscriptions
             ->start($startDate);
     }
 
+    public function hasSubscription(Plan $plan): bool
+    {
+        return $this->subscription()
+            ->where('plan_id', $plan->id)
+            ->exists();
+    }
+
     public function switchTo(Plan $plan, $expiration = null, $immediately = true): Subscription
     {
         if ($immediately) {


### PR DESCRIPTION
Fixing error:

Illuminate\Database\QueryException
SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default value for 'expired_at' (SQL: create table `subscriptions` (`id` bigint unsigned not null auto_increment primary key, `plan_id` bigint unsigned not null, `canceled_at` timestamp null, `expired_at` timestamp not null, `grace_days_ended_at` timestamp null, `started_at` date not null, `suppressed_at` timestamp null, `was_switched` tinyint(1) not null default '0', `deleted_at` timestamp null, `created_at` timestamp null, `updated_at` timestamp null, `subscriber_type` varchar(255) not null, `subscriber_id` bigint unsigned not null) default character set utf8mb4 collate 'utf8mb4_unicode_ci')

When trying to migrate database