### PR TITLE
Added documentation for fetching remaining charges

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,13 @@ If you don't pass any arguments, the method will suppress the current subscripti
 
 > This call will fire a `SubscriptionStarted(Subscription $subscription)` event.
 
+### Fetching remaining Charges
+
+If you need remaining charges of a user, simply call the method `getRemainingCharges`. Imagine a scenario where a student has consumable feature named `notes-download`. To get remaining downloads limit:
+```php
+$student->getRemainingCharges('notes-download');
+```
+
 #### Scheduling a Switch
 
 If you want to keep your user with the current plan until its expiration, pass the `$immediately` parameter as `false`:


### PR DESCRIPTION
There was no documentation about how to get subscriber's balance or such stuffs. I had to suffer figuring it out. So now I've added it in the README file so that other people don't have to suffer any more.