### PR TITLE
Bugfix: The balance of the feature was miscalculated and was considering every subscriber

### DIFF
--- a/src/Models/Concerns/HasSubscriptions.php
+++ b/src/Models/Concerns/HasSubscriptions.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use InvalidArgumentException;
 use LogicException;
 use LucasDotVin\Soulbscription\Events\FeatureConsumed;
@@ -380,8 +381,13 @@ trait HasSubscriptions
             return $this->loadedTicketFeatures;
         }
 
-        return $this->loadedTicketFeatures = Feature::with(['tickets' => fn ($query) => $query->withoutExpired()->whereMorphedTo('subscriber', $this)])
-            ->whereHas('tickets', fn (Builder $query) => $query->withoutExpired()->whereMorphedTo('subscriber', $this))
+        return $this->loadedTicketFeatures = Feature::with([
+                'tickets' => fn (HasMany $query) => $query->withoutExpired()->whereMorphedTo('subscriber', $this),
+            ])
+            ->whereHas(
+                'tickets',
+                fn (Builder $query) => $query->withoutExpired()->whereMorphedTo('subscriber', $this),
+            )
             ->get();
     }
 }

--- a/src/Models/Concerns/HasSubscriptions.php
+++ b/src/Models/Concerns/HasSubscriptions.php
@@ -380,7 +380,7 @@ trait HasSubscriptions
             return $this->loadedTicketFeatures;
         }
 
-        return $this->loadedTicketFeatures = Feature::with('tickets')
+        return $this->loadedTicketFeatures = Feature::with(['tickets' => fn ($query) => $query->withoutExpired()->whereMorphedTo('subscriber', $this)])
             ->whereHas('tickets', fn (Builder $query) => $query->withoutExpired()->whereMorphedTo('subscriber', $this))
             ->get();
     }

--- a/tests/Models/Concerns/HasSubscriptionsTest.php
+++ b/tests/Models/Concerns/HasSubscriptionsTest.php
@@ -951,4 +951,21 @@ class HasSubscriptionsTest extends TestCase
 
         $this->assertLessThan(0, $subscriber->balance($feature->name));
     }
+
+    public function testItReturnsRemainingChargesOnlyForTheGivenUser()
+    {
+        config(['soulbscription.feature_tickets' => true]);
+
+        $charges = $this->faker->numberBetween(5, 10);
+
+        $feature = Feature::factory()->createOne();
+
+        $subscriber = User::factory()->createOne();
+        $subscriber->giveTicketFor($feature->name, null, $charges);
+
+        $otherSubscriber = User::factory()->createOne();
+        $otherSubscriber->giveTicketFor($feature->name, null, $charges);
+
+        $this->assertEquals($charges, $subscriber->getRemainingCharges($feature->name));
+    }
 }

--- a/tests/Models/Concerns/HasSubscriptionsTest.php
+++ b/tests/Models/Concerns/HasSubscriptionsTest.php
@@ -917,7 +917,7 @@ class HasSubscriptionsTest extends TestCase
     public function testItDoesNotReturnNegativeChargesForFeatures()
     {
         $charges = $this->faker->numberBetween(5, 10);
-        $consumption = $this->faker->numberBetween($charges, $charges * 2);
+        $consumption = $this->faker->numberBetween($charges + 1, $charges * 2);
 
         $plan = Plan::factory()->createOne();
         $feature = Feature::factory()->postpaid()->createOne();
@@ -936,7 +936,7 @@ class HasSubscriptionsTest extends TestCase
     public function testItReturnsNegativeBalanceForFeatures()
     {
         $charges = $this->faker->numberBetween(5, 10);
-        $consumption = $this->faker->numberBetween($charges, $charges * 2);
+        $consumption = $this->faker->numberBetween($charges + 1, $charges * 2);
 
         $plan = Plan::factory()->createOne();
         $feature = Feature::factory()->postpaid()->createOne();


### PR DESCRIPTION
The issue is that when a feature ticket is assigned to the subscriber, and if there are more than 1 subscriber for the same ticket, the package loads the balance as summed up for all the feature tickets.

The whereHas has the scope for who is the subscriber, but the with misses the scope, and because of that, when the feature tickets for a particular feature is loaded, it loaded summed up charges for the tickets assigned to anyone.

Example:

I assign 5 charges as a feature ticket when a user confirms their account:

```php
$user->giveTicketFor('document', null, 5);
```

So this happens for each user who registered and confirmed their account.

Now when we see how much balance for each user has using:

```php
$user->balance('document')
```

If the system has only 1 user, it will return 5.

If there are more than one users, say n users, it will return 5 * n.