### PR TITLE
Using a config instead of a model directly

### DIFF
--- a/src/Models/Concerns/HasSubscriptions.php
+++ b/src/Models/Concerns/HasSubscriptions.php
@@ -194,7 +194,8 @@ trait HasSubscriptions
             new LogicException('The tickets are not enabled in the configs.'),
         );
 
-        $feature = Feature::whereName($featureName)->firstOrFail();
+        $featureModel = config('soulbscription.models.feature');
+        $feature = $featureModel::whereName($featureName)->firstOrFail();
 
         $featureTicket = $this->featureTickets()
             ->make([
@@ -386,7 +387,8 @@ trait HasSubscriptions
             return $this->loadedTicketFeatures;
         }
 
-        return $this->loadedTicketFeatures = Feature::with([
+        $featureModel = config('soulbscription.models.feature');
+        return $this->loadedTicketFeatures = $featureModel::with([
                 'tickets' => fn (HasMany $query) => $query->withoutExpired()->whereMorphedTo('subscriber', $this),
             ])
             ->whereHas(


### PR DESCRIPTION
I defined my model in the config, but it wasn't being called in a few places, so I fixed that.
In my case this is important because I am using multiple databases and I need to add a `getConnectionName` method to the model.

<img width="630" alt="Screenshot 2023-10-18 at 22 28 38" src="https://github.com/noxoua/laravel-soulbscription/assets/142592979/5ae5a719-7c1a-466f-9c90-ea9618db5361">
