### PR TITLE
Fixed giveTicketFor method

### DIFF
--- a/src/Models/Concerns/HasSubscriptions.php
+++ b/src/Models/Concerns/HasSubscriptions.php
@@ -187,7 +187,7 @@ trait HasSubscriptions
      * @throws LogicException
      * @throws ModelNotFoundException
      */
-    public function giveTicketFor($featureName, $expiration = null, ?float $charges = null): FeatureTicket
+    public function giveTicketFor($featureId, $expiration = null, ?float $charges = null): FeatureTicket
     {
         throw_unless(
             config('soulbscription.feature_tickets'),
@@ -195,7 +195,7 @@ trait HasSubscriptions
         );
 
         $featureModel = config('soulbscription.models.feature');
-        $feature = $featureModel::whereName($featureName)->firstOrFail();
+        $feature = $featureModel::whereKey($featureId)->firstOrFail();
 
         $featureTicket = $this->featureTickets()
             ->make([


### PR DESCRIPTION
Getting a feature must be done by ID, because there could be many features with the same name.

## example:

### plan-1
 - deploy-minutes:30
 -  ...
 
### plan-2
 - deploy-minutes:60
 -  ...

### plan-3
 - deploy-minutes:90
 -  ...

### plan-4
 - deploy-minutes:120
 - ...
