### PR TITLE
fix deprecation for carbon 3

### DIFF
--- a/src/Enums/PeriodicityType.php
+++ b/src/Enums/PeriodicityType.php
@@ -21,6 +21,6 @@ class PeriodicityType
 
         $differenceMethodName = 'diffIn' . $unitInPlural;
 
-        return $from->{$differenceMethodName}($to);
+        return (int) $from->{$differenceMethodName}($to);
     }
 }


### PR DESCRIPTION
my laravel config is setup to log deprecations, i got this:
```
production.WARNING: ErrorException: Implicit conversion from float -1.9990081062193847 to int loses precision 
in /app/vendor/lucasdotvin/laravel-soulbscription/src/Enums/PeriodicityType.php:24
```

As [Carbon documentation](https://carbon.nesbot.com/docs/#api-difference) says:

> diffAsCarbonInterval() and diffIn*() (and floatDiffIn*() for versions < 3 when diffIn*() methods returned integer values, 
> since Carbon 3, they are deprecated as diffIn*() already return floating number, and integer values from it can easily be
> obtained with an explicit cast (int)).

