### PR TITLE
Fix a critical bug: refactors model bindings to use config-based resolution

### DIFF
--- a/database/factories/FeatureConsumptionFactory.php
+++ b/database/factories/FeatureConsumptionFactory.php
@@ -2,13 +2,15 @@
 
 namespace LucasDotVin\Soulbscription\Database\Factories;
 
-use LucasDotVin\Soulbscription\Models\Feature;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use LucasDotVin\Soulbscription\Models\FeatureConsumption;
-
 class FeatureConsumptionFactory extends Factory
 {
-    protected $model = FeatureConsumption::class;
+    protected $model;
+
+    public function __construct()
+    {
+        $this->model = config('soulbscription.models.feature_consumption');
+    }
 
     /**
      * Define the model's default state.
@@ -18,7 +20,7 @@ class FeatureConsumptionFactory extends Factory
     public function definition()
     {
         return [
-            'feature_id'      => Feature::factory(),
+            'feature_id'      => config('soulbscription.models.feature')::factory(),
             'consumption'     => $this->faker->randomFloat(),
             'expired_at'      => $this->faker->dateTime(),
             'subscriber_id'   => $this->faker->randomNumber(),

--- a/database/factories/FeatureFactory.php
+++ b/database/factories/FeatureFactory.php
@@ -4,11 +4,15 @@ namespace LucasDotVin\Soulbscription\Database\Factories;
 
 use LucasDotVin\Soulbscription\Enums\PeriodicityType;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use LucasDotVin\Soulbscription\Models\Feature;
 
 class FeatureFactory extends Factory
 {
-    protected $model = Feature::class;
+    protected $model;
+
+    public function __construct()
+    {
+        $this->model = config('soulbscription.models.feature');
+    }
 
     /**
      * Define the model's default state.

--- a/database/factories/PlanFactory.php
+++ b/database/factories/PlanFactory.php
@@ -4,11 +4,15 @@ namespace LucasDotVin\Soulbscription\Database\Factories;
 
 use LucasDotVin\Soulbscription\Enums\PeriodicityType;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use LucasDotVin\Soulbscription\Models\Plan;
 
 class PlanFactory extends Factory
 {
-    protected $model = Plan::class;
+    protected $model;
+
+    public function __construct()
+    {
+        $this->model = config('soulbscription.models.plan');
+    }
 
     /**
      * Define the model's default state.

--- a/database/factories/SubscriptionFactory.php
+++ b/database/factories/SubscriptionFactory.php
@@ -2,13 +2,16 @@
 
 namespace LucasDotVin\Soulbscription\Database\Factories;
 
-use LucasDotVin\Soulbscription\Models\Plan;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use LucasDotVin\Soulbscription\Models\Subscription;
 
 class SubscriptionFactory extends Factory
 {
-    protected $model = Subscription::class;
+    protected $model;
+
+    public function __construct()
+    {
+        $this->model = config('soulbscription.models.subscription');
+    }
 
     /**
      * Define the model's default state.
@@ -18,7 +21,7 @@ class SubscriptionFactory extends Factory
     public function definition()
     {
         return [
-            'plan_id'         => Plan::factory(),
+            'plan_id'         => config('soulbscription.models.plan')::factory(),
             'canceled_at'     => null,
             'started_at'      => $this->faker->dateTime(),
             'suppressed_at'   => null,

--- a/database/factories/SubscriptionRenewalFactory.php
+++ b/database/factories/SubscriptionRenewalFactory.php
@@ -2,12 +2,16 @@
 
 namespace LucasDotVin\Soulbscription\Database\Factories;
 
-use LucasDotVin\Soulbscription\Models\{Subscription, SubscriptionRenewal};
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class SubscriptionRenewalFactory extends Factory
 {
-    protected $model = SubscriptionRenewal::class;
+    protected $model;
+
+    public function __construct()
+    {
+        $this->model = config('soulbscription.models.subscription_renewal');
+    }
 
     /**
      * Define the model's default state.
@@ -17,7 +21,7 @@ class SubscriptionRenewalFactory extends Factory
     public function definition()
     {
         return [
-            'subscription_id' => Subscription::factory(),
+            'subscription_id' => config('soulbscription.models.subscription')::factory(),
             'overdue'         => $this->faker->boolean(),
             'renewal'         => $this->faker->boolean(),
         ];

--- a/database/migrations/2022_02_01_235539_create_subscriptions_table.php
+++ b/database/migrations/2022_02_01_235539_create_subscriptions_table.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class() extends Migration {
@@ -15,7 +14,7 @@ return new class() extends Migration {
     {
         Schema::create('subscriptions', function (Blueprint $table) {
             $table->id();
-            $table->foreignIdFor(\LucasDotVin\Soulbscription\Models\Plan::class);
+            $table->foreignIdFor(config('soulbscription.models.plan')::class);
             $table->timestamp('canceled_at')->nullable();
             $table->timestamp('expired_at')->nullable();
             $table->timestamp('grace_days_ended_at')->nullable();

--- a/database/migrations/2022_02_02_000527_create_feature_consumptions_table.php
+++ b/database/migrations/2022_02_02_000527_create_feature_consumptions_table.php
@@ -16,7 +16,7 @@ return new class() extends Migration {
             $table->id();
             $table->decimal('consumption')->unsigned()->nullable();
             $table->timestamp('expired_at')->nullable();
-            $table->foreignIdFor(\LucasDotVin\Soulbscription\Models\Feature::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(config('soulbscription.models.feature')::class)->constrained()->cascadeOnDelete();
             $table->timestamps();
 
             if (config('soulbscription.models.subscriber.uses_uuid')) {

--- a/database/migrations/2022_02_03_001206_create_subscription_renewals_table.php
+++ b/database/migrations/2022_02_03_001206_create_subscription_renewals_table.php
@@ -16,7 +16,7 @@ return new class () extends Migration {
             $table->id();
             $table->boolean('overdue');
             $table->boolean('renewal');
-            $table->foreignIdFor(\LucasDotVin\Soulbscription\Models\Subscription::class);
+            $table->foreignIdFor(config('soulbscription.models.subscription')::class);
             $table->timestamps();
         });
     }

--- a/database/migrations/2022_02_04_001622_create_feature_plan_table.php
+++ b/database/migrations/2022_02_04_001622_create_feature_plan_table.php
@@ -15,8 +15,8 @@ return new class () extends Migration {
         Schema::create('feature_plan', function (Blueprint $table) {
             $table->id();
             $table->decimal('charges')->nullable();
-            $table->foreignIdFor(\LucasDotVin\Soulbscription\Models\Feature::class)->constrained()->cascadeOnDelete();
-            $table->foreignIdFor(\LucasDotVin\Soulbscription\Models\Plan::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(config('soulbscription.models.plan')::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(config('soulbscription.models.feature')::class)->constrained()->cascadeOnDelete();
             $table->timestamps();
         });
     }

--- a/database/migrations/2022_02_25_001622_create_feature_tickets_table.php
+++ b/database/migrations/2022_02_25_001622_create_feature_tickets_table.php
@@ -16,7 +16,7 @@ return new class() extends Migration {
             $table->id();
             $table->decimal('charges')->nullable();
             $table->timestamp('expired_at')->nullable();
-            $table->foreignIdFor(\LucasDotVin\Soulbscription\Models\Feature::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(config('soulbscription.models.feature')::class)->constrained()->cascadeOnDelete();
             $table->timestamps();
 
             if (config('soulbscription.models.subscriber.uses_uuid')) {

--- a/src/Events/FeatureConsumed.php
+++ b/src/Events/FeatureConsumed.php
@@ -2,23 +2,39 @@
 
 namespace LucasDotVin\Soulbscription\Events;
 
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
+use InvalidArgumentException;
 use Illuminate\Queue\SerializesModels;
-use LucasDotVin\Soulbscription\Models\Feature;
-use LucasDotVin\Soulbscription\Models\FeatureConsumption;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
 
 class FeatureConsumed
 {
     use Dispatchable;
-    use InteractsWithSockets;
     use SerializesModels;
+    use InteractsWithSockets;
+
+    public mixed $feature;
+    public mixed $subscriber;
+    public mixed $featureConsumption;
 
     public function __construct(
-        public $subscriber,
-        public Feature $feature,
-        public FeatureConsumption $featureConsumption,
+        $subscriber,
+        mixed $feature,
+        mixed $featureConsumption
     ) {
-        //
+        $featureClass = config('soulbscription.models.feature');
+        $featureConsumptionClass = config('soulbscription.models.feature_consumption');
+
+        throw_if(!($feature instanceof $featureClass), new InvalidArgumentException(
+            "Feature must be an instance of $featureClass."
+        ));
+
+        throw_if(!($featureConsumption instanceof $featureConsumptionClass), new InvalidArgumentException(
+            "FeatureConsumption must be an instance of $featureConsumptionClass."
+        ));
+
+        $this->feature = $feature;
+        $this->subscriber = $subscriber;
+        $this->featureConsumption = $featureConsumption;
     }
 }

--- a/src/Events/FeatureTicketCreated.php
+++ b/src/Events/FeatureTicketCreated.php
@@ -2,23 +2,39 @@
 
 namespace LucasDotVin\Soulbscription\Events;
 
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
+use InvalidArgumentException;
 use Illuminate\Queue\SerializesModels;
-use LucasDotVin\Soulbscription\Models\Feature;
-use LucasDotVin\Soulbscription\Models\FeatureTicket;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
 
 class FeatureTicketCreated
 {
     use Dispatchable;
-    use InteractsWithSockets;
     use SerializesModels;
+    use InteractsWithSockets;
+
+    public mixed $feature;
+    public mixed $subscriber;
+    public mixed $featureTicket;
 
     public function __construct(
-        public $subscriber,
-        public Feature $feature,
-        public FeatureTicket $featureTicket,
+        $subscriber,
+        mixed $feature,
+        mixed $featureTicket
     ) {
-        //
+        $featureClass = config('soulbscription.models.feature');
+        $featureTicketClass = config('soulbscription.models.feature_ticket');
+
+        throw_if(!($feature instanceof $featureClass), new InvalidArgumentException(
+            "Feature must be an instance of $featureClass."
+        ));
+
+        throw_if(!($featureTicket instanceof $featureTicketClass), new InvalidArgumentException(
+            "FeatureTicket must be an instance of $featureTicketClass."
+        ));
+
+        $this->feature = $feature;
+        $this->subscriber = $subscriber;
+        $this->featureTicket = $featureTicket;
     }
 }

--- a/src/Events/SubscriptionCanceled.php
+++ b/src/Events/SubscriptionCanceled.php
@@ -2,20 +2,27 @@
 
 namespace LucasDotVin\Soulbscription\Events;
 
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
+use InvalidArgumentException;
 use Illuminate\Queue\SerializesModels;
-use LucasDotVin\Soulbscription\Models\Subscription;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
 
 class SubscriptionCanceled
 {
     use Dispatchable;
-    use InteractsWithSockets;
     use SerializesModels;
+    use InteractsWithSockets;
 
-    public function __construct(
-        public Subscription $subscription,
-    ) {
-        //
+    public mixed $subscription;
+
+    public function __construct(mixed $subscription)
+    {
+        $subscriptionClass = config('soulbscription.models.subscription');
+
+        throw_if(!($subscription instanceof $subscriptionClass), new InvalidArgumentException(
+            "Subscription must be an instance of $subscriptionClass."
+        ));
+
+        $this->subscription = $subscription;
     }
 }

--- a/src/Events/SubscriptionRenewed.php
+++ b/src/Events/SubscriptionRenewed.php
@@ -2,20 +2,27 @@
 
 namespace LucasDotVin\Soulbscription\Events;
 
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
+use InvalidArgumentException;
 use Illuminate\Queue\SerializesModels;
-use LucasDotVin\Soulbscription\Models\Subscription;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
 
 class SubscriptionRenewed
 {
     use Dispatchable;
-    use InteractsWithSockets;
     use SerializesModels;
+    use InteractsWithSockets;
 
-    public function __construct(
-        public Subscription $subscription,
-    ) {
-        //
+    public mixed $subscription;
+
+    public function __construct(mixed $subscription)
+    {
+        $subscriptionClass = config('soulbscription.models.subscription');
+
+        throw_if(!($subscription instanceof $subscriptionClass), new InvalidArgumentException(
+            "Subscription must be an instance of $subscriptionClass."
+        ));
+
+        $this->subscription = $subscription;
     }
 }

--- a/src/Events/SubscriptionScheduled.php
+++ b/src/Events/SubscriptionScheduled.php
@@ -2,20 +2,27 @@
 
 namespace LucasDotVin\Soulbscription\Events;
 
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
+use InvalidArgumentException;
 use Illuminate\Queue\SerializesModels;
-use LucasDotVin\Soulbscription\Models\Subscription;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
 
 class SubscriptionScheduled
 {
     use Dispatchable;
-    use InteractsWithSockets;
     use SerializesModels;
+    use InteractsWithSockets;
 
-    public function __construct(
-        public Subscription $subscription,
-    ) {
-        //
+    public mixed $subscription;
+
+    public function __construct(mixed $subscription)
+    {
+        $subscriptionClass = config('soulbscription.models.subscription');
+
+        throw_if(!($subscription instanceof $subscriptionClass), new InvalidArgumentException(
+            "Subscription must be an instance of $subscriptionClass."
+        ));
+
+        $this->subscription = $subscription;
     }
 }

--- a/src/Events/SubscriptionStarted.php
+++ b/src/Events/SubscriptionStarted.php
@@ -2,20 +2,26 @@
 
 namespace LucasDotVin\Soulbscription\Events;
 
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
-use LucasDotVin\Soulbscription\Models\Subscription;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
 
 class SubscriptionStarted
 {
     use Dispatchable;
-    use InteractsWithSockets;
     use SerializesModels;
+    use InteractsWithSockets;
 
-    public function __construct(
-        public Subscription $subscription,
-    ) {
-        //
+    public mixed $subscription;
+
+    public function __construct(mixed $subscription)
+    {
+        $subscriptionClass = config('soulbscription.models.subscription');
+
+        throw_if(!($subscription instanceof $subscriptionClass), new InvalidArgumentException(
+            "Subscription must be an instance of $subscriptionClass."
+        ));
+
+        $this->subscription = $subscription;
     }
 }

--- a/src/Events/SubscriptionSuppressed.php
+++ b/src/Events/SubscriptionSuppressed.php
@@ -2,10 +2,10 @@
 
 namespace LucasDotVin\Soulbscription\Events;
 
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Foundation\Events\Dispatchable;
+use InvalidArgumentException;
 use Illuminate\Queue\SerializesModels;
-use LucasDotVin\Soulbscription\Models\Subscription;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
 
 class SubscriptionSuppressed
 {
@@ -13,9 +13,16 @@ class SubscriptionSuppressed
     use InteractsWithSockets;
     use SerializesModels;
 
-    public function __construct(
-        public Subscription $subscription,
-    ) {
-        //
+    public mixed $subscription;
+
+    public function __construct(mixed $subscription)
+    {
+        $subscriptionClass = config('soulbscription.models.subscription');
+
+        throw_if(!($subscription instanceof $subscriptionClass), new InvalidArgumentException(
+            "Subscription must be an instance of $subscriptionClass."
+        ));
+
+        $this->subscription = $subscription;
     }
 }

--- a/tests/Models/Concerns/ExpiresAndHasGraceDaysTest.php
+++ b/tests/Models/Concerns/ExpiresAndHasGraceDaysTest.php
@@ -2,23 +2,36 @@
 
 namespace Tests\Feature\Models\Concerns;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use InvalidArgumentException;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use LucasDotVin\Soulbscription\Models\Concerns\ExpiresAndHasGraceDays;
 use LucasDotVin\Soulbscription\Models\Scopes\ExpiringWithGraceDaysScope;
-use LucasDotVin\Soulbscription\Models\Subscription;
-use Tests\TestCase;
 
 class ExpiresAndHasGraceDaysTest extends TestCase
 {
-    use RefreshDatabase;
     use WithFaker;
+    use RefreshDatabase;
 
-    public const MODEL = Subscription::class;
+    public const MODEL = 'soulbscription.models.subscription';
+
+    protected function getModelClass()
+    {
+        $modelClass = config(self::MODEL);
+
+        throw_if(!is_a($modelClass, Model::class, true), new InvalidArgumentException(
+            "Configured subscription model must be a subclass of " . Model::class
+        ));
+
+        return $modelClass;
+    }
 
     public function testTraitAppliesScope()
     {
-        $model = self::MODEL::factory()->create();
+        $modelClass = $this->getModelClass();
+        $model = $modelClass::factory()->create();
 
         $this->assertArrayHasKey(ExpiresAndHasGraceDays::class, class_uses_recursive($model));
         $this->assertArrayHasKey(ExpiringWithGraceDaysScope::class, $model->getGlobalScopes());
@@ -26,25 +39,19 @@ class ExpiresAndHasGraceDaysTest extends TestCase
 
     public function testModelReturnsExpiredStatus()
     {
-        $expiredModel = self::MODEL::factory()
-            ->expired()
-            ->create();
+        $modelClass = $this->getModelClass();
 
-        $expiredModelWithFutureGraceDays = self::MODEL::factory()
-            ->expired()
-            ->create([
-                'grace_days_ended_at' => now()->addDay(),
-            ]);
+        $expiredModel = $modelClass::factory()->expired()->create();
 
-        $expiredModelWithPastGraceDays = self::MODEL::factory()
-            ->expired()
-            ->create([
-                'grace_days_ended_at' => now()->subDay(),
-            ]);
+        $expiredModelWithFutureGraceDays = $modelClass::factory()->expired()->create([
+            'grace_days_ended_at' => now()->addDay(),
+        ]);
 
-        $notExpiredModel = self::MODEL::factory()
-            ->notExpired()
-            ->create();
+        $expiredModelWithPastGraceDays = $modelClass::factory()->expired()->create([
+            'grace_days_ended_at' => now()->subDay(),
+        ]);
+
+        $notExpiredModel = $modelClass::factory()->notExpired()->create();
 
         $this->assertTrue($expiredModel->expired());
         $this->assertFalse($expiredModelWithFutureGraceDays->expired());
@@ -54,31 +61,23 @@ class ExpiresAndHasGraceDaysTest extends TestCase
 
     public function testModelReturnsNotExpiredStatus()
     {
-        $expiredModel = self::MODEL::factory()
-            ->expired()
-            ->create();
+        $modelClass = $this->getModelClass();
 
-        $modelWithNullExpiredAt = self::MODEL::factory()
-            ->expired()
-            ->create([
-                'expired_at' => null,
-            ]);
+        $expiredModel = $modelClass::factory()->expired()->create();
 
-        $expiredModelWithFutureGraceDays = self::MODEL::factory()
-            ->expired()
-            ->create([
-                'grace_days_ended_at' => now()->addDay(),
-            ]);
+        $modelWithNullExpiredAt = $modelClass::factory()->expired()->create([
+            'expired_at' => null,
+        ]);
 
-        $expiredModelWithPastGraceDays = self::MODEL::factory()
-            ->expired()
-            ->create([
-                'grace_days_ended_at' => now()->subDay(),
-            ]);
+        $expiredModelWithFutureGraceDays = $modelClass::factory()->expired()->create([
+            'grace_days_ended_at' => now()->addDay(),
+        ]);
 
-        $notExpiredModel = self::MODEL::factory()
-            ->notExpired()
-            ->create();
+        $expiredModelWithPastGraceDays = $modelClass::factory()->expired()->create([
+            'grace_days_ended_at' => now()->subDay(),
+        ]);
+
+        $notExpiredModel = $modelClass::factory()->notExpired()->create();
 
         $this->assertFalse($expiredModel->notExpired());
         $this->assertTrue($expiredModelWithFutureGraceDays->notExpired());
@@ -89,31 +88,23 @@ class ExpiresAndHasGraceDaysTest extends TestCase
 
     public function testModelReturnsIfItHasExpired()
     {
-        $expiredModel = self::MODEL::factory()
-            ->expired()
-            ->create();
+        $modelClass = $this->getModelClass();
 
-        $modelWithNullExpiredAt = self::MODEL::factory()
-            ->expired()
-            ->create([
-                'expired_at' => null,
-            ]);
+        $expiredModel = $modelClass::factory()->expired()->create();
 
-        $expiredModelWithFutureGraceDays = self::MODEL::factory()
-            ->expired()
-            ->create([
-                'grace_days_ended_at' => now()->addDay(),
-            ]);
+        $modelWithNullExpiredAt = $modelClass::factory()->expired()->create([
+            'expired_at' => null,
+        ]);
 
-        $expiredModelWithPastGraceDays = self::MODEL::factory()
-            ->expired()
-            ->create([
-                'grace_days_ended_at' => now()->subDay(),
-            ]);
+        $expiredModelWithFutureGraceDays = $modelClass::factory()->expired()->create([
+            'grace_days_ended_at' => now()->addDay(),
+        ]);
 
-        $notExpiredModel = self::MODEL::factory()
-            ->notExpired()
-            ->create();
+        $expiredModelWithPastGraceDays = $modelClass::factory()->expired()->create([
+            'grace_days_ended_at' => now()->subDay(),
+        ]);
+
+        $notExpiredModel = $modelClass::factory()->notExpired()->create();
 
         $this->assertTrue($expiredModel->hasExpired());
         $this->assertFalse($expiredModelWithFutureGraceDays->hasExpired());
@@ -124,31 +115,23 @@ class ExpiresAndHasGraceDaysTest extends TestCase
 
     public function testModelReturnsIfItHasNotExpired()
     {
-        $expiredModel = self::MODEL::factory()
-            ->expired()
-            ->create();
+        $modelClass = $this->getModelClass();
 
-        $modelWithNullExpiredAt = self::MODEL::factory()
-            ->expired()
-            ->create([
-                'expired_at' => null,
-            ]);
+        $expiredModel = $modelClass::factory()->expired()->create();
 
-        $expiredModelWithFutureGraceDays = self::MODEL::factory()
-            ->expired()
-            ->create([
-                'grace_days_ended_at' => now()->addDay(),
-            ]);
+        $modelWithNullExpiredAt = $modelClass::factory()->expired()->create([
+            'expired_at' => null,
+        ]);
 
-        $expiredModelWithPastGraceDays = self::MODEL::factory()
-            ->expired()
-            ->create([
-                'grace_days_ended_at' => now()->subDay(),
-            ]);
+        $expiredModelWithFutureGraceDays = $modelClass::factory()->expired()->create([
+            'grace_days_ended_at' => now()->addDay(),
+        ]);
 
-        $notExpiredModel = self::MODEL::factory()
-            ->notExpired()
-            ->create();
+        $expiredModelWithPastGraceDays = $modelClass::factory()->expired()->create([
+            'grace_days_ended_at' => now()->subDay(),
+        ]);
+
+        $notExpiredModel = $modelClass::factory()->notExpired()->create();
 
         $this->assertFalse($expiredModel->hasNotExpired());
         $this->assertTrue($expiredModelWithFutureGraceDays->hasNotExpired());

--- a/tests/Models/Concerns/HandlesRecurrenceTest.php
+++ b/tests/Models/Concerns/HandlesRecurrenceTest.php
@@ -2,26 +2,39 @@
 
 namespace Tests\Feature\Models\Concerns;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Carbon;
-use LucasDotVin\Soulbscription\Enums\PeriodicityType;
-use LucasDotVin\Soulbscription\Models\Plan;
 use Tests\TestCase;
+use InvalidArgumentException;
+use Illuminate\Support\Carbon;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use LucasDotVin\Soulbscription\Enums\PeriodicityType;
 
 class HandlesRecurrenceTest extends TestCase
 {
-    use RefreshDatabase;
     use WithFaker;
+    use RefreshDatabase;
 
-    public const MODEL = Plan::class;
+    public const MODEL = 'soulbscription.models.plan';
+
+    protected function getModelClass()
+    {
+        $modelClass = config(self::MODEL);
+
+        throw_if(!is_a($modelClass, Model::class, true), new InvalidArgumentException(
+            "Configured plan model must be a subclass of " . Model::class
+        ));
+
+        return $modelClass;
+    }
 
     public function testModelCalculateYearlyExpiration()
     {
         Carbon::setTestNow(now());
 
         $years = $this->faker->randomDigitNotNull();
-        $plan = self::MODEL::factory()->create([
+        $modelClass = $this->getModelClass();
+        $plan = $modelClass::factory()->create([
             'periodicity_type' => PeriodicityType::Year,
             'periodicity' => $years,
         ]);
@@ -34,7 +47,8 @@ class HandlesRecurrenceTest extends TestCase
         Carbon::setTestNow(now());
 
         $months = $this->faker->randomDigitNotNull();
-        $plan = self::MODEL::factory()->create([
+        $modelClass = $this->getModelClass();
+        $plan = $modelClass::factory()->create([
             'periodicity_type' => PeriodicityType::Month,
             'periodicity' => $months,
         ]);
@@ -47,7 +61,8 @@ class HandlesRecurrenceTest extends TestCase
         Carbon::setTestNow(now());
 
         $weeks = $this->faker->randomDigitNotNull();
-        $plan = self::MODEL::factory()->create([
+        $modelClass = $this->getModelClass();
+        $plan = $modelClass::factory()->create([
             'periodicity_type' => PeriodicityType::Week,
             'periodicity' => $weeks,
         ]);
@@ -60,7 +75,8 @@ class HandlesRecurrenceTest extends TestCase
         Carbon::setTestNow(now());
 
         $days = $this->faker->randomDigitNotNull();
-        $plan = self::MODEL::factory()->create([
+        $modelClass = $this->getModelClass();
+        $plan = $modelClass::factory()->create([
             'periodicity_type' => PeriodicityType::Day,
             'periodicity' => $days,
         ]);
@@ -73,7 +89,8 @@ class HandlesRecurrenceTest extends TestCase
         Carbon::setTestNow(now());
 
         $weeks = $this->faker->randomDigitNotNull();
-        $plan = self::MODEL::factory()->create([
+        $modelClass = $this->getModelClass();
+        $plan = $modelClass::factory()->create([
             'periodicity_type' => PeriodicityType::Week,
             'periodicity' => $weeks,
         ]);
@@ -88,7 +105,8 @@ class HandlesRecurrenceTest extends TestCase
         Carbon::setTestNow(today());
 
         $weeks = $this->faker->randomDigitNotNull();
-        $plan = self::MODEL::factory()->create([
+        $modelClass = $this->getModelClass();
+        $plan = $modelClass::factory()->create([
             'periodicity_type' => PeriodicityType::Week,
             'periodicity' => $weeks,
         ]);
@@ -97,7 +115,7 @@ class HandlesRecurrenceTest extends TestCase
 
         $this->assertEquals(
             $start->copy()->addWeeks($weeks),
-            $plan->calculateNextRecurrenceEnd($start->toDateTimeString()),
+            $plan->calculateNextRecurrenceEnd($start->toDateTimeString())
         );
     }
 }

--- a/tests/Models/Concerns/HasSubscriptionsTest.php
+++ b/tests/Models/Concerns/HasSubscriptionsTest.php
@@ -2,36 +2,34 @@
 
 namespace Tests\Feature\Models\Concerns;
 
-use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use Tests\Mocks\Models\User;
+
+use LogicException;
+use OverflowException;
+use OutOfBoundsException;
+use InvalidArgumentException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
-use InvalidArgumentException;
-use LogicException;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use LucasDotVin\Soulbscription\Events\FeatureConsumed;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use LucasDotVin\Soulbscription\Events\SubscriptionStarted;
 use LucasDotVin\Soulbscription\Events\FeatureTicketCreated;
 use LucasDotVin\Soulbscription\Events\SubscriptionScheduled;
-use LucasDotVin\Soulbscription\Events\SubscriptionStarted;
 use LucasDotVin\Soulbscription\Events\SubscriptionSuppressed;
-use LucasDotVin\Soulbscription\Models\Feature;
-use LucasDotVin\Soulbscription\Models\FeatureConsumption;
-use LucasDotVin\Soulbscription\Models\Plan;
-use LucasDotVin\Soulbscription\Models\Subscription;
-use LucasDotVin\Soulbscription\Models\SubscriptionRenewal;
-use OutOfBoundsException;
-use OverflowException;
-use Tests\Mocks\Models\User;
-use Tests\TestCase;
+
+
 
 class HasSubscriptionsTest extends TestCase
 {
-    use RefreshDatabase;
     use WithFaker;
+    use RefreshDatabase;
 
     public function testModelCanSubscribeToAPlan()
     {
-        $plan = Plan::factory()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
         $subscriber = User::factory()->createOne();
 
         Event::fake();
@@ -52,7 +50,7 @@ class HasSubscriptionsTest extends TestCase
 
     public function testModelDefinesGraceDaysEnd()
     {
-        $plan = Plan::factory()
+        $plan = config('soulbscription.models.plan')::factory()
             ->withGraceDays()
             ->createOne();
 
@@ -68,8 +66,8 @@ class HasSubscriptionsTest extends TestCase
     {
         Carbon::setTestNow(now());
 
-        $oldPlan = Plan::factory()->createOne();
-        $newPlan = Plan::factory()->createOne();
+        $oldPlan = config('soulbscription.models.plan')::factory()->createOne();
+        $newPlan = config('soulbscription.models.plan')::factory()->createOne();
 
         $subscriber = User::factory()->createOne();
         $oldSubscription = $subscriber->subscribeTo($oldPlan);
@@ -100,8 +98,8 @@ class HasSubscriptionsTest extends TestCase
     {
         Carbon::setTestNow(now());
 
-        $oldPlan = Plan::factory()->createOne();
-        $newPlan = Plan::factory()->createOne();
+        $oldPlan = config('soulbscription.models.plan')::factory()->createOne();
+        $newPlan = config('soulbscription.models.plan')::factory()->createOne();
 
         $subscriber = User::factory()->createOne();
         $oldSubscription = $subscriber->subscribeTo($oldPlan);
@@ -128,8 +126,8 @@ class HasSubscriptionsTest extends TestCase
 
     public function testModelGetNewSubscriptionAfterSwitching()
     {
-        $oldPlan = Plan::factory()->createOne();
-        $newPlan = Plan::factory()->createOne();
+        $oldPlan = config('soulbscription.models.plan')::factory()->createOne();
+        $newPlan = config('soulbscription.models.plan')::factory()->createOne();
 
         $subscriber = User::factory()->createOne();
         $subscriber->subscribeTo($oldPlan, startDate: now()->subDay());
@@ -143,8 +141,8 @@ class HasSubscriptionsTest extends TestCase
     {
         Carbon::setTestNow(now());
 
-        $oldPlan = Plan::factory()->createOne();
-        $newPlan = Plan::factory()->createOne();
+        $oldPlan = config('soulbscription.models.plan')::factory()->createOne();
+        $newPlan = config('soulbscription.models.plan')::factory()->createOne();
 
         $subscriber = User::factory()->createOne();
         $oldSubscription = $subscriber->subscribeTo($oldPlan);
@@ -159,8 +157,8 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(5, 10);
         $consumption = $this->faker->numberBetween(1, $charges);
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->consumable()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $charges,
         ]);
@@ -184,8 +182,8 @@ class HasSubscriptionsTest extends TestCase
 
     public function testModelCanConsumeANotConsumableFeatureIfItIsAvailable()
     {
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->notConsumable()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->notConsumable()->createOne();
         $feature->plans()->attach($plan);
 
         $subscriber = User::factory()->createOne();
@@ -205,8 +203,8 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(5, 10);
         $consumption = $this->faker->numberBetween(1, $charges);
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->consumable()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $charges,
         ]);
@@ -231,8 +229,8 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(5, 10);
         $consumption = $charges + 1;
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->consumable()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $charges,
         ]);
@@ -257,8 +255,8 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(5, 10);
         $consumption = $this->faker->numberBetween(1, $charges);
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->consumable()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $charges,
         ]);
@@ -276,8 +274,8 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(5, 10);
         $consumption = $this->faker->numberBetween(1, $charges);
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->consumable()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $charges,
         ]);
@@ -295,8 +293,8 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(5, 10);
         $consumption = $charges + 1;
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->consumable()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $charges,
         ]);
@@ -314,8 +312,8 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(5, 10);
         $consumption = $this->faker->numberBetween(1, $charges);
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->consumable()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $charges,
         ]);
@@ -323,7 +321,7 @@ class HasSubscriptionsTest extends TestCase
         $subscriber = User::factory()->createOne();
         $subscriber->subscribeTo($plan);
 
-        FeatureConsumption::factory()
+        config('soulbscription.models.feature_consumption')::factory()
             ->for($feature)
             ->for($subscriber, 'subscriber')
             ->createOne([
@@ -339,12 +337,12 @@ class HasSubscriptionsTest extends TestCase
     public function testModelHasSubscriptionRenewals()
     {
         $subscriber = User::factory()->createOne();
-        $subscription = Subscription::factory()
+        $subscription = config('soulbscription.models.subscription')::factory()
             ->for($subscriber, 'subscriber')
             ->createOne();
 
         $renewalsCount = $this->faker->randomDigitNotNull();
-        $renewals = SubscriptionRenewal::factory()
+        $renewals = config('soulbscription.models.subscription_renewal')::factory()
             ->times($renewalsCount)
             ->for($subscription)
             ->createOne();
@@ -357,7 +355,7 @@ class HasSubscriptionsTest extends TestCase
 
     public function testModelHasFeatureTickets()
     {
-        $feature = Feature::factory()->consumable()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
 
         $subscriber = User::factory()->createOne();
 
@@ -375,7 +373,7 @@ class HasSubscriptionsTest extends TestCase
 
     public function testModelFeatureTicketsGetsOnlyNotExpired()
     {
-        $feature = Feature::factory()->consumable()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
 
         $subscriber = User::factory()->createOne();
 
@@ -408,7 +406,7 @@ class HasSubscriptionsTest extends TestCase
 
     public function testModelGetFeaturesFromTickets()
     {
-        $feature = Feature::factory()->consumable()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
 
         $subscriber = User::factory()->createOne();
 
@@ -429,7 +427,7 @@ class HasSubscriptionsTest extends TestCase
 
     public function testModelGetFeaturesFromNonExpirableTickets()
     {
-        $feature = Feature::factory()->consumable()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
 
         $subscriber = User::factory()->createOne();
 
@@ -453,7 +451,7 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(5, 10);
         $consumption = $this->faker->numberBetween(1, $charges);
 
-        $feature = Feature::factory()->consumable()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
         $subscriber = User::factory()->createOne();
 
         $ticket = $subscriber->featureTickets()->make([
@@ -476,9 +474,9 @@ class HasSubscriptionsTest extends TestCase
         $subscriptionFeatureCharges = $this->faker->numberBetween(5, 10);
         $ticketFeatureCharges = $this->faker->numberBetween(5, 10);
 
-        $feature = Feature::factory()->consumable()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
 
-        $plan = Plan::factory()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $subscriptionFeatureCharges,
         ]);
@@ -503,7 +501,7 @@ class HasSubscriptionsTest extends TestCase
 
     public function testModelCanConsumeANotConsumableFeatureFromATicket()
     {
-        $feature = Feature::factory()->notConsumable()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->notConsumable()->createOne();
         $subscriber = User::factory()->createOne();
 
         $ticket = $subscriber->featureTickets()->make([
@@ -524,8 +522,8 @@ class HasSubscriptionsTest extends TestCase
     {
         $consumption = $this->faker->randomDigitNotNull();
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->consumable()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
         $feature->plans()->attach($plan);
 
         $subscriber = User::factory()->createOne();
@@ -551,8 +549,8 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(6, 10);
         $consumption = $this->faker->numberBetween(1, 5);
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->consumable()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $charges,
         ]);
@@ -577,10 +575,10 @@ class HasSubscriptionsTest extends TestCase
 
     public function testModelCantUseChargesFromExpiredTickets()
     {
-        $feature = Feature::factory()->consumable()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
         $subscriber = User::factory()->createOne();
 
-        $plan = Plan::factory()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
         $subscriber->subscribeTo($plan);
 
         $subscriptionFeatureCharges = $this->faker->numberBetween(5, 10);
@@ -615,10 +613,10 @@ class HasSubscriptionsTest extends TestCase
 
     public function testItIgnoresTicketsWhenItIsDisabled()
     {
-        $feature = Feature::factory()->consumable()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
         $subscriber = User::factory()->createOne();
 
-        $plan = Plan::factory()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
         $plan->features()->attach($feature);
         $subscriber->subscribeTo($plan);
 
@@ -644,7 +642,7 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->randomDigitNotNull();
         $expiration = $this->faker->dateTime();
 
-        $feature = Feature::factory()->consumable()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
 
         $subscriber = User::factory()->createOne();
 
@@ -663,7 +661,7 @@ class HasSubscriptionsTest extends TestCase
     {
         $charges = $this->faker->randomDigitNotNull();
 
-        $feature = Feature::factory()->consumable()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
 
         $subscriber = User::factory()->createOne();
 
@@ -683,7 +681,7 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->randomDigitNotNull();
         $expiration = $this->faker->dateTime();
 
-        $feature = Feature::factory()->consumable()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
 
         $subscriber = User::factory()->createOne();
 
@@ -717,7 +715,7 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->randomDigitNotNull();
         $expiration = $this->faker->dateTime();
 
-        $feature = Feature::factory()->consumable()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->consumable()->createOne();
 
         $subscriber = User::factory()->createOne();
 
@@ -734,8 +732,8 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(5, 10);
         $consumption = $this->faker->numberBetween(1, $charges);
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->quota()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->quota()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $charges,
         ]);
@@ -758,8 +756,8 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(5, 10);
         $consumption = $this->faker->numberBetween(1, $charges / 2);
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->quota()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->quota()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $charges,
         ]);
@@ -784,8 +782,8 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(5, 10);
         $consumption = $this->faker->numberBetween(1, $charges / 2);
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->quota()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->quota()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $charges,
         ]);
@@ -810,8 +808,8 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(5, 10);
         $consumption = $this->faker->numberBetween(1, $charges / 2);
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->notQuota()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->notQuota()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $charges,
         ]);
@@ -827,7 +825,7 @@ class HasSubscriptionsTest extends TestCase
 
     public function testItChecksIfTheUserHasSubscriptionToAPlan()
     {
-        $plan = Plan::factory()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
 
         $subscriber = User::factory()->createOne();
         $subscriber->subscribeTo($plan);
@@ -841,7 +839,7 @@ class HasSubscriptionsTest extends TestCase
 
     public function testItChecksIfTheUserDoesNotHaveSubscriptionToAPlan()
     {
-        $plan = Plan::factory()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
 
         $subscriber = User::factory()->createOne();
         $subscriber->subscribeTo($plan);
@@ -855,7 +853,7 @@ class HasSubscriptionsTest extends TestCase
 
     public function testItReturnsTheLastSubscriptionWhenRetrievingExpired()
     {
-        $plan = Plan::factory()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
 
         $subscriber = User::factory()->createOne();
         $subscriber->subscribeTo($plan, now()->subDay(), now()->subDay());
@@ -871,8 +869,8 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(5, 10);
         $consumption = $this->faker->numberBetween(1, $charges * 2);
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->postpaid()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->postpaid()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $charges,
         ]);
@@ -894,8 +892,8 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(5, 10);
         $consumption = $this->faker->numberBetween($charges + 1, $charges * 2);
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->postpaid()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->postpaid()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $charges,
         ]);
@@ -913,8 +911,8 @@ class HasSubscriptionsTest extends TestCase
         $charges = $this->faker->numberBetween(5, 10);
         $consumption = $this->faker->numberBetween($charges + 1, $charges * 2);
 
-        $plan = Plan::factory()->createOne();
-        $feature = Feature::factory()->postpaid()->createOne();
+        $plan = config('soulbscription.models.plan')::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->postpaid()->createOne();
         $feature->plans()->attach($plan, [
             'charges' => $charges,
         ]);
@@ -933,7 +931,7 @@ class HasSubscriptionsTest extends TestCase
 
         $charges = $this->faker->numberBetween(5, 10);
 
-        $feature = Feature::factory()->createOne();
+        $feature = config('soulbscription.models.feature')::factory()->createOne();
 
         $subscriber = User::factory()->createOne();
         $subscriber->giveTicketFor($feature->name, null, $charges);

--- a/tests/Models/Concerns/StartsTest.php
+++ b/tests/Models/Concerns/StartsTest.php
@@ -2,21 +2,34 @@
 
 namespace Tests\Feature\Models\Concerns;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use LucasDotVin\Soulbscription\Models\Subscription;
 use Tests\TestCase;
+use InvalidArgumentException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class StartsTest extends TestCase
 {
-    use RefreshDatabase;
     use WithFaker;
+    use RefreshDatabase;
 
-    public const MODEL = Subscription::class;
+    public const MODEL = 'soulbscription.models.subscription';
+
+    protected function getModelClass()
+    {
+        $modelClass = config(self::MODEL);
+
+        throw_if(!is_a($modelClass, Model::class, true), new InvalidArgumentException(
+            "Configured subscription model must be a subclass of " . Model::class
+        ));
+
+        return $modelClass;
+    }
 
     public function testModelReturnsStartedWhenStartedAtIsOnThePast()
     {
-        $model = self::MODEL::factory()->make([
+        $modelClass = $this->getModelClass();
+        $model = $modelClass::factory()->make([
             'started_at' => now()->subDay(),
         ]);
 
@@ -26,7 +39,8 @@ class StartsTest extends TestCase
 
     public function testModelReturnsNotStartedWhenStartedAtIsOnTheFuture()
     {
-        $model = self::MODEL::factory()->make([
+        $modelClass = $this->getModelClass();
+        $model = $modelClass::factory()->make([
             'started_at' => now()->addDay(),
         ]);
 
@@ -36,7 +50,8 @@ class StartsTest extends TestCase
 
     public function testModelReturnsNotStartedWhenStartedAtIsNull()
     {
-        $model = self::MODEL::factory()->make();
+        $modelClass = $this->getModelClass();
+        $model = $modelClass::factory()->make();
         $model->started_at = null;
 
         $this->assertFalse($model->started());

--- a/tests/Models/Concerns/SuppressesTest.php
+++ b/tests/Models/Concerns/SuppressesTest.php
@@ -2,21 +2,34 @@
 
 namespace Tests\Feature\Models\Concerns;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use LucasDotVin\Soulbscription\Models\Subscription;
 use Tests\TestCase;
+use InvalidArgumentException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class SuppressesTest extends TestCase
 {
-    use RefreshDatabase;
     use WithFaker;
+    use RefreshDatabase;
 
-    public const MODEL = Subscription::class;
+    public const MODEL = 'soulbscription.models.subscription';
+
+    protected function getModelClass()
+    {
+        $modelClass = config(self::MODEL);
+
+        throw_if(!is_a($modelClass, Model::class, true), new InvalidArgumentException(
+            "Configured subscription model must be a subclass of " . Model::class
+        ));
+
+        return $modelClass;
+    }
 
     public function testModelReturnsSuppressedWhenSuppressedAtIsOnThePast()
     {
-        $model = self::MODEL::factory()->make([
+        $modelClass = $this->getModelClass();
+        $model = $modelClass::factory()->make([
             'suppressed_at' => now()->subDay(),
         ]);
 
@@ -26,7 +39,8 @@ class SuppressesTest extends TestCase
 
     public function testModelReturnsNotSuppressedWhenSuppressedAtIsOnTheFuture()
     {
-        $model = self::MODEL::factory()->make([
+        $modelClass = $this->getModelClass();
+        $model = $modelClass::factory()->make([
             'suppressed_at' => now()->addDay(),
         ]);
 
@@ -36,7 +50,8 @@ class SuppressesTest extends TestCase
 
     public function testModelReturnsNotSuppressedWhenSuppressedAtIsNull()
     {
-        $model = self::MODEL::factory()->make();
+        $modelClass = $this->getModelClass();
+        $model = $modelClass::factory()->make();
         $model->suppressed_at = null;
 
         $this->assertFalse($model->suppressed());

--- a/tests/Models/FeaturePlanTest.php
+++ b/tests/Models/FeaturePlanTest.php
@@ -2,40 +2,37 @@
 
 namespace Tests\Feature\Models;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use LucasDotVin\Soulbscription\Models\Feature;
-use LucasDotVin\Soulbscription\Models\FeaturePlan;
-use LucasDotVin\Soulbscription\Models\Plan;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class FeaturePlanTest extends TestCase
 {
-    use RefreshDatabase;
     use WithFaker;
+    use RefreshDatabase;
 
     public function testModelCanRetrievePlan()
     {
-        $feature = Feature::factory()
+        $feature = config('soulbscription.models.feature')::factory()
             ->create();
 
-        $plan = Plan::factory()->create();
+        $plan = config('soulbscription.models.plan')::factory()->create();
         $plan->features()->attach($feature);
 
-        $featurePlanPivot = FeaturePlan::first();
+        $featurePlanPivot = config('soulbscription.models.feature_plan')::first();
 
         $this->assertEquals($plan->id, $featurePlanPivot->plan->id);
     }
 
     public function testModelCanRetrieveFeature()
     {
-        $feature = Feature::factory()
+        $feature = config('soulbscription.models.feature')::factory()
             ->create();
 
-        $plan = Plan::factory()->create();
+        $plan = config('soulbscription.models.plan')::factory()->create();
         $plan->features()->attach($feature);
 
-        $featurePlanPivot = FeaturePlan::first();
+        $featurePlanPivot = config('soulbscription.models.feature_plan')::first();
 
         $this->assertEquals($feature->id, $featurePlanPivot->feature->id);
     }

--- a/tests/Models/FeatureTest.php
+++ b/tests/Models/FeatureTest.php
@@ -2,12 +2,11 @@
 
 namespace Tests\Feature\Models;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Carbon;
-use LucasDotVin\Soulbscription\Enums\PeriodicityType;
-use LucasDotVin\Soulbscription\Models\Feature;
 use Tests\TestCase;
+use Illuminate\Support\Carbon;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use LucasDotVin\Soulbscription\Enums\PeriodicityType;
 
 class FeatureTest extends TestCase
 {
@@ -19,7 +18,7 @@ class FeatureTest extends TestCase
         Carbon::setTestNow(now());
 
         $years = $this->faker->randomDigitNotNull();
-        $feature = Feature::factory()->create([
+        $feature = config('soulbscription.models.feature')::factory()->create([
             'periodicity_type' => PeriodicityType::Year,
             'periodicity' => $years,
         ]);
@@ -32,7 +31,7 @@ class FeatureTest extends TestCase
         Carbon::setTestNow(now());
 
         $months = $this->faker->randomDigitNotNull();
-        $feature = Feature::factory()->create([
+        $feature = config('soulbscription.models.feature')::factory()->create([
             'periodicity_type' => PeriodicityType::Month,
             'periodicity' => $months,
         ]);
@@ -45,7 +44,7 @@ class FeatureTest extends TestCase
         Carbon::setTestNow(now());
 
         $weeks = $this->faker->randomDigitNotNull();
-        $feature = Feature::factory()->create([
+        $feature = config('soulbscription.models.feature')::factory()->create([
             'periodicity_type' => PeriodicityType::Week,
             'periodicity' => $weeks,
         ]);
@@ -58,7 +57,7 @@ class FeatureTest extends TestCase
         Carbon::setTestNow(now());
 
         $days = $this->faker->randomDigitNotNull();
-        $feature = Feature::factory()->create([
+        $feature = config('soulbscription.models.feature')::factory()->create([
             'periodicity_type' => PeriodicityType::Day,
             'periodicity' => $days,
         ]);
@@ -70,7 +69,7 @@ class FeatureTest extends TestCase
     {
         Carbon::setTestNow(now());
 
-        $feature = Feature::factory()->create([
+        $feature = config('soulbscription.models.feature')::factory()->create([
             'periodicity_type' => PeriodicityType::Week,
             'periodicity' => 1,
         ]);
@@ -82,11 +81,11 @@ class FeatureTest extends TestCase
 
     public function testModelIsNotQuotaByDefault()
     {
-        $creationPayload = Feature::factory()->raw();
+        $creationPayload = config('soulbscription.models.feature')::factory()->raw();
 
         unset($creationPayload['quota']);
 
-        $feature = Feature::create($creationPayload);
+        $feature = config('soulbscription.models.feature')::create($creationPayload);
 
         $this->assertDatabaseHas('features', [
             'id' => $feature->id,

--- a/tests/Models/PlanTest.php
+++ b/tests/Models/PlanTest.php
@@ -2,13 +2,11 @@
 
 namespace Tests\Feature\Models;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Carbon;
-use LucasDotVin\Soulbscription\Enums\PeriodicityType;
-use LucasDotVin\Soulbscription\Models\Plan;
-use LucasDotVin\Soulbscription\Models\Subscription;
 use Tests\TestCase;
+use Illuminate\Support\Carbon;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use LucasDotVin\Soulbscription\Enums\PeriodicityType;
 
 class PlanTest extends TestCase
 {
@@ -21,7 +19,7 @@ class PlanTest extends TestCase
 
         $days = $this->faker->randomDigitNotNull();
         $graceDays = $this->faker->randomDigitNotNull();
-        $plan = Plan::factory()->create([
+        $plan = config('soulbscription.models.plan')::factory()->create([
             'grace_days' => $graceDays,
             'periodicity_type' => PeriodicityType::Day,
             'periodicity' => $days,
@@ -35,10 +33,10 @@ class PlanTest extends TestCase
 
     public function testModelCanRetrieveSubscriptions()
     {
-        $plan = Plan::factory()
+        $plan = config('soulbscription.models.plan')::factory()
             ->create();
 
-        $subscriptions = Subscription::factory()
+        $subscriptions = config('soulbscription.models.subscription')::factory()
             ->for($plan)
             ->count($subscriptionsCount = $this->faker->randomDigitNotNull())
             ->started()
@@ -54,7 +52,7 @@ class PlanTest extends TestCase
 
     public function testPlanCanBeCreatedWithoutPeriodicity()
     {
-        $plan = Plan::factory()
+        $plan = config('soulbscription.models.plan')::factory()
             ->create([
                 'periodicity' => null,
                 'periodicity_type' => null,

--- a/tests/Models/SubscriptionTest.php
+++ b/tests/Models/SubscriptionTest.php
@@ -2,31 +2,29 @@
 
 namespace Tests\Feature\Models;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use Tests\Mocks\Models\User;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use LucasDotVin\Soulbscription\Events\SubscriptionCanceled;
 use LucasDotVin\Soulbscription\Events\SubscriptionRenewed;
 use LucasDotVin\Soulbscription\Events\SubscriptionStarted;
 use LucasDotVin\Soulbscription\Events\SubscriptionSuppressed;
-use LucasDotVin\Soulbscription\Models\Plan;
-use LucasDotVin\Soulbscription\Models\Subscription;
-use Tests\Mocks\Models\User;
-use Tests\TestCase;
 
 class SubscriptionTest extends TestCase
 {
-    use RefreshDatabase;
     use WithFaker;
+    use RefreshDatabase;
 
     public function testModelRenews()
     {
         Carbon::setTestNow(now());
 
-        $plan = Plan::factory()->create();
+        $plan = config('soulbscription.models.plan')::factory()->create();
         $subscriber = User::factory()->create();
-        $subscription = Subscription::factory()
+        $subscription = config('soulbscription.models.subscription')::factory()
             ->for($plan)
             ->for($subscriber, 'subscriber')
             ->create([
@@ -53,9 +51,9 @@ class SubscriptionTest extends TestCase
     {
         Carbon::setTestNow(now());
 
-        $plan = Plan::factory()->create();
+        $plan = config('soulbscription.models.plan')::factory()->create();
         $subscriber = User::factory()->create();
-        $subscription = Subscription::factory()
+        $subscription = config('soulbscription.models.subscription')::factory()
             ->for($plan)
             ->for($subscriber, 'subscriber')
             ->create([
@@ -82,9 +80,9 @@ class SubscriptionTest extends TestCase
     {
         Carbon::setTestNow(now());
 
-        $plan = Plan::factory()->create();
+        $plan = config('soulbscription.models.plan')::factory()->create();
         $subscriber = User::factory()->create();
-        $subscription = Subscription::factory()
+        $subscription = config('soulbscription.models.subscription')::factory()
             ->for($plan)
             ->for($subscriber, 'subscriber')
             ->notStarted()
@@ -106,9 +104,9 @@ class SubscriptionTest extends TestCase
     {
         Carbon::setTestNow(now());
 
-        $plan = Plan::factory()->create();
+        $plan = config('soulbscription.models.plan')::factory()->create();
         $subscriber = User::factory()->create();
-        $subscription = Subscription::factory()
+        $subscription = config('soulbscription.models.subscription')::factory()
             ->for($plan)
             ->for($subscriber, 'subscriber')
             ->notStarted()
@@ -130,9 +128,9 @@ class SubscriptionTest extends TestCase
     {
         Carbon::setTestNow(now());
 
-        $plan = Plan::factory()->create();
+        $plan = config('soulbscription.models.plan')::factory()->create();
         $subscriber = User::factory()->create();
-        $subscription = Subscription::factory()
+        $subscription = config('soulbscription.models.subscription')::factory()
             ->for($plan)
             ->for($subscriber, 'subscriber')
             ->create();
@@ -151,9 +149,9 @@ class SubscriptionTest extends TestCase
 
     public function testModelCanMarkAsSwitched()
     {
-        $plan = Plan::factory()->create();
+        $plan = config('soulbscription.models.plan')::factory()->create();
         $subscriber = User::factory()->create();
-        $subscription = Subscription::factory()
+        $subscription = config('soulbscription.models.subscription')::factory()
             ->for($plan)
             ->for($subscriber, 'subscriber')
             ->create();
@@ -170,7 +168,7 @@ class SubscriptionTest extends TestCase
     public function testModelRegistersRenewal()
     {
         $subscriber = User::factory()->create();
-        $subscription = Subscription::factory()
+        $subscription = config('soulbscription.models.subscription')::factory()
             ->for($subscriber, 'subscriber')
             ->create();
 
@@ -186,7 +184,7 @@ class SubscriptionTest extends TestCase
     public function testModelRegistersOverdue()
     {
         $subscriber = User::factory()->create();
-        $subscription = Subscription::factory()
+        $subscription = config('soulbscription.models.subscription')::factory()
             ->for($subscriber, 'subscriber')
             ->create([
                 'expired_at' => now()->subDay(),
@@ -204,7 +202,7 @@ class SubscriptionTest extends TestCase
     public function testModelConsidersGraceDaysOnOverdue()
     {
         $subscriber = User::factory()->create();
-        $subscription = Subscription::factory()
+        $subscription = config('soulbscription.models.subscription')::factory()
             ->for($subscriber, 'subscriber')
             ->create([
                 'grace_days_ended_at' => now()->addDay(),
@@ -222,21 +220,21 @@ class SubscriptionTest extends TestCase
 
     public function testModelReturnsNotStartedSubscriptionsInNotActiveScope()
     {
-        Subscription::factory()
+        config('soulbscription.models.subscription')::factory()
             ->count($this->faker()->randomDigitNotNull())
             ->started()
             ->notExpired()
             ->notSuppressed()
             ->create();
 
-        $notStartedSubscription = Subscription::factory()
+        $notStartedSubscription = config('soulbscription.models.subscription')::factory()
             ->count($notStartedSubscriptionCount = $this->faker()->randomDigitNotNull())
             ->notStarted()
             ->notExpired()
             ->notSuppressed()
             ->create();
 
-        $returnedSubscriptions = Subscription::notActive()->get();
+        $returnedSubscriptions = config('soulbscription.models.subscription')::notActive()->get();
 
         $this->assertCount($notStartedSubscriptionCount, $returnedSubscriptions);
         $notStartedSubscription->each(
@@ -246,21 +244,21 @@ class SubscriptionTest extends TestCase
 
     public function testModelReturnsExpiredSubscriptionsInNotActiveScope()
     {
-        Subscription::factory()
+        config('soulbscription.models.subscription')::factory()
             ->count($this->faker()->randomDigitNotNull())
             ->started()
             ->notExpired()
             ->notSuppressed()
             ->create();
 
-        $expiredSubscription = Subscription::factory()
+        $expiredSubscription = config('soulbscription.models.subscription')::factory()
             ->count($expiredSubscriptionCount = $this->faker()->randomDigitNotNull())
             ->started()
             ->expired()
             ->notSuppressed()
             ->create();
 
-        $returnedSubscriptions = Subscription::notActive()->get();
+        $returnedSubscriptions = config('soulbscription.models.subscription')::notActive()->get();
 
         $this->assertCount($expiredSubscriptionCount, $returnedSubscriptions);
         $expiredSubscription->each(
@@ -270,21 +268,21 @@ class SubscriptionTest extends TestCase
 
     public function testModelReturnsSuppressedSubscriptionsInNotActiveScope()
     {
-        Subscription::factory()
+        config('soulbscription.models.subscription')::factory()
             ->count($this->faker()->randomDigitNotNull())
             ->started()
             ->notExpired()
             ->notSuppressed()
             ->create();
 
-        $suppressedSubscription = Subscription::factory()
+        $suppressedSubscription = config('soulbscription.models.subscription')::factory()
             ->count($suppressedSubscriptionCount = $this->faker()->randomDigitNotNull())
             ->started()
             ->notExpired()
             ->suppressed()
             ->create();
 
-        $returnedSubscriptions = Subscription::notActive()->get();
+        $returnedSubscriptions = config('soulbscription.models.subscription')::notActive()->get();
 
         $this->assertCount($suppressedSubscriptionCount, $returnedSubscriptions);
         $suppressedSubscription->each(
@@ -294,7 +292,7 @@ class SubscriptionTest extends TestCase
 
     public function testModelReturnsOnlyCanceledSubscriptionsWithTheScope()
     {
-        Subscription::factory()
+        config('soulbscription.models.subscription')::factory()
             ->count($this->faker()->randomDigitNotNull())
             ->started()
             ->notExpired()
@@ -302,7 +300,7 @@ class SubscriptionTest extends TestCase
             ->notCanceled()
             ->create();
 
-        $canceledSubscription = Subscription::factory()
+        $canceledSubscription = config('soulbscription.models.subscription')::factory()
             ->count($canceledSubscriptionCount = $this->faker()->randomDigitNotNull())
             ->started()
             ->notExpired()
@@ -310,7 +308,7 @@ class SubscriptionTest extends TestCase
             ->canceled()
             ->create();
 
-        $returnedSubscriptions = Subscription::canceled()->get();
+        $returnedSubscriptions = config('soulbscription.models.subscription')::canceled()->get();
 
         $this->assertCount($canceledSubscriptionCount, $returnedSubscriptions);
         $canceledSubscription->each(
@@ -320,7 +318,7 @@ class SubscriptionTest extends TestCase
 
     public function testModelReturnsOnlyNotCanceledSubscriptionsWithTheScope()
     {
-        Subscription::factory()
+        config('soulbscription.models.subscription')::factory()
             ->count($this->faker()->randomDigitNotNull())
             ->started()
             ->notExpired()
@@ -328,7 +326,7 @@ class SubscriptionTest extends TestCase
             ->canceled()
             ->create();
 
-        $notCanceledSubscription = Subscription::factory()
+        $notCanceledSubscription = config('soulbscription.models.subscription')::factory()
             ->count($notCanceledSubscriptionCount = $this->faker()->randomDigitNotNull())
             ->started()
             ->notExpired()
@@ -336,7 +334,7 @@ class SubscriptionTest extends TestCase
             ->notCanceled()
             ->create();
 
-        $returnedSubscriptions = Subscription::notCanceled()->get();
+        $returnedSubscriptions = config('soulbscription.models.subscription')::notCanceled()->get();
 
         $this->assertCount($notCanceledSubscriptionCount, $returnedSubscriptions);
         $notCanceledSubscription->each(

--- a/tests/Scopes/StartingScopeTest.php
+++ b/tests/Scopes/StartingScopeTest.php
@@ -2,33 +2,47 @@
 
 namespace Tests\Feature\Models;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use LucasDotVin\Soulbscription\Models\Subscription;
 use Tests\TestCase;
+use InvalidArgumentException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class StartingScopeTest extends TestCase
 {
-    use RefreshDatabase;
     use WithFaker;
+    use RefreshDatabase;
 
-    public const MODEL = Subscription::class;
+    public const MODEL = 'soulbscription.models.subscription';
+
+    protected function getModelClass()
+    {
+        $modelClass = config(self::MODEL);
+
+        throw_if(!is_a($modelClass, Model::class, true), new InvalidArgumentException(
+            "Configured subscription model must be a subclass of " . Model::class
+        ));
+
+        return $modelClass;
+    }
 
     public function testNotStartedModelsAreNotReturnedByDefault()
     {
-        $startedModelsCount = $this->faker()->randomDigitNotNull();
-        $startedModels = self::MODEL::factory()->count($startedModelsCount)->create([
+        $modelClass = $this->getModelClass();
+        $startedModelsCount = $this->faker->randomDigitNotNull();
+
+        $startedModels = $modelClass::factory()->count($startedModelsCount)->create([
             'expired_at' => now()->addDay(),
             'started_at' => now()->subDay(),
         ]);
 
-        $notStartedModelsCount = $this->faker()->randomDigitNotNull();
-        self::MODEL::factory()->count($notStartedModelsCount)->create([
+        $notStartedModelsCount = $this->faker->randomDigitNotNull();
+        $modelClass::factory()->count($notStartedModelsCount)->create([
             'expired_at' => now()->addDay(),
             'started_at' => now()->addDay(),
         ]);
 
-        $returnedSubscriptions = self::MODEL::all();
+        $returnedSubscriptions = $modelClass::all();
 
         $this->assertEqualsCanonicalizing(
             $startedModels->pluck('id')->toArray(),
@@ -38,19 +52,21 @@ class StartingScopeTest extends TestCase
 
     public function testNotStartedModelsAreNotReturnedWhenCallingWithoutNotStarted()
     {
-        $startedModelsCount = $this->faker()->randomDigitNotNull();
-        $startedModels = self::MODEL::factory()->count($startedModelsCount)->create([
+        $modelClass = $this->getModelClass();
+        $startedModelsCount = $this->faker->randomDigitNotNull();
+
+        $startedModels = $modelClass::factory()->count($startedModelsCount)->create([
             'expired_at' => now()->addDay(),
             'started_at' => now()->subDay(),
         ]);
 
-        $notStartedModelsCount = $this->faker()->randomDigitNotNull();
-        self::MODEL::factory()->count($notStartedModelsCount)->create([
+        $notStartedModelsCount = $this->faker->randomDigitNotNull();
+        $modelClass::factory()->count($notStartedModelsCount)->create([
             'expired_at' => now()->addDay(),
             'started_at' => now()->addDay(),
         ]);
 
-        $returnedSubscriptions = self::MODEL::withoutNotStarted()->get();
+        $returnedSubscriptions = $modelClass::withoutNotStarted()->get();
 
         $this->assertEqualsCanonicalizing(
             $startedModels->pluck('id')->toArray(),
@@ -60,21 +76,22 @@ class StartingScopeTest extends TestCase
 
     public function testStartedModelsAreReturnedWhenCallingMethodWithNotStarted()
     {
-        $startedModelsCount = $this->faker()->randomDigitNotNull();
-        $startedModels = self::MODEL::factory()->count($startedModelsCount)->create([
+        $modelClass = $this->getModelClass();
+        $startedModelsCount = $this->faker->randomDigitNotNull();
+
+        $startedModels = $modelClass::factory()->count($startedModelsCount)->create([
             'expired_at' => now()->addDay(),
             'started_at' => now()->subDay(),
         ]);
 
-        $notStartedModelsCount = $this->faker()->randomDigitNotNull();
-        $notStartedModels = self::MODEL::factory()->count($notStartedModelsCount)->create([
+        $notStartedModelsCount = $this->faker->randomDigitNotNull();
+        $notStartedModels = $modelClass::factory()->count($notStartedModelsCount)->create([
             'expired_at' => now()->addDay(),
             'started_at' => now()->addDay(),
         ]);
 
         $expectedSubscriptions = $startedModels->concat($notStartedModels);
-
-        $returnedSubscriptions = self::MODEL::withNotStarted()->get();
+        $returnedSubscriptions = $modelClass::withNotStarted()->get();
 
         $this->assertEqualsCanonicalizing(
             $expectedSubscriptions->pluck('id')->toArray(),
@@ -84,19 +101,21 @@ class StartingScopeTest extends TestCase
 
     public function testNotStartedModelsAreReturnedWhenCallingMethodWithNotStartedAndPassingAFalse()
     {
-        $startedModelsCount = $this->faker()->randomDigitNotNull();
-        $startedModels = self::MODEL::factory()->count($startedModelsCount)->create([
+        $modelClass = $this->getModelClass();
+        $startedModelsCount = $this->faker->randomDigitNotNull();
+
+        $startedModels = $modelClass::factory()->count($startedModelsCount)->create([
             'expired_at' => now()->addDay(),
             'started_at' => now()->subDay(),
         ]);
 
-        $notStartedModelsCount = $this->faker()->randomDigitNotNull();
-        self::MODEL::factory()->count($notStartedModelsCount)->create([
+        $notStartedModelsCount = $this->faker->randomDigitNotNull();
+        $modelClass::factory()->count($notStartedModelsCount)->create([
             'expired_at' => now()->addDay(),
             'started_at' => now()->addDay(),
         ]);
 
-        $returnedSubscriptions = self::MODEL::withNotStarted(false)->get();
+        $returnedSubscriptions = $modelClass::withNotStarted(false)->get();
 
         $this->assertEqualsCanonicalizing(
             $startedModels->pluck('id')->toArray(),
@@ -106,19 +125,21 @@ class StartingScopeTest extends TestCase
 
     public function testOnlyStartedModelsAreReturnedWhenCallingMethodOnlyNotStarted()
     {
-        $startedModelsCount = $this->faker()->randomDigitNotNull();
-        self::MODEL::factory()->count($startedModelsCount)->create([
+        $modelClass = $this->getModelClass();
+        $startedModelsCount = $this->faker->randomDigitNotNull();
+
+        $modelClass::factory()->count($startedModelsCount)->create([
             'expired_at' => now()->addDay(),
             'started_at' => now()->subDay(),
         ]);
 
-        $notStartedModelsCount = $this->faker()->randomDigitNotNull();
-        $notStartedModels = self::MODEL::factory()->count($notStartedModelsCount)->create([
+        $notStartedModelsCount = $this->faker->randomDigitNotNull();
+        $notStartedModels = $modelClass::factory()->count($notStartedModelsCount)->create([
             'expired_at' => now()->addDay(),
             'started_at' => now()->addDay(),
         ]);
 
-        $returnedSubscriptions = self::MODEL::onlyNotStarted()->get();
+        $returnedSubscriptions = $modelClass::onlyNotStarted()->get();
 
         $this->assertEqualsCanonicalizing(
             $notStartedModels->pluck('id')->toArray(),

--- a/tests/Scopes/SuppressingScopeTest.php
+++ b/tests/Scopes/SuppressingScopeTest.php
@@ -2,37 +2,51 @@
 
 namespace Tests\Feature\Models;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use LucasDotVin\Soulbscription\Models\Subscription;
 use Tests\TestCase;
+use InvalidArgumentException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class SuppressingScopeTest extends TestCase
 {
-    use RefreshDatabase;
     use WithFaker;
+    use RefreshDatabase;
 
-    public const MODEL = Subscription::class;
+    public const MODEL = 'soulbscription.models.subscription';
+
+    protected function getModelClass()
+    {
+        $modelClass = config(self::MODEL);
+
+        throw_if(!is_a($modelClass, Model::class, true), new InvalidArgumentException(
+            "Configured subscription model must be a subclass of " . Model::class
+        ));
+
+        return $modelClass;
+    }
 
     public function testSuppressedModelsAreNotReturnedByDefault()
     {
-        $suppressedModelsCount = $this->faker()->randomDigitNotNull();
-        self::MODEL::factory()
+        $modelClass = $this->getModelClass();
+        $suppressedModelsCount = $this->faker->randomDigitNotNull();
+
+        $modelClass::factory()
             ->count($suppressedModelsCount)
             ->suppressed()
             ->notExpired()
             ->started()
             ->create();
 
-        $notSuppressedModelsCount = $this->faker()->randomDigitNotNull();
-        $notSuppressedModels = self::MODEL::factory()
+        $notSuppressedModelsCount = $this->faker->randomDigitNotNull();
+        $notSuppressedModels = $modelClass::factory()
             ->count($notSuppressedModelsCount)
             ->notSuppressed()
             ->notExpired()
             ->started()
             ->create();
 
-        $returnedSubscriptions = self::MODEL::all();
+        $returnedSubscriptions = $modelClass::all();
 
         $this->assertEqualsCanonicalizing(
             $notSuppressedModels->pluck('id')->toArray(),
@@ -42,23 +56,25 @@ class SuppressingScopeTest extends TestCase
 
     public function testSuppressedModelsAreNotReturnedWhenCallingWithoutNotSuppressed()
     {
-        $suppressedModelsCount = $this->faker()->randomDigitNotNull();
-        self::MODEL::factory()
+        $modelClass = $this->getModelClass();
+        $suppressedModelsCount = $this->faker->randomDigitNotNull();
+
+        $modelClass::factory()
             ->count($suppressedModelsCount)
             ->suppressed()
             ->notExpired()
             ->started()
             ->create();
 
-        $notSuppressedModelsCount = $this->faker()->randomDigitNotNull();
-        $notSuppressedModels = self::MODEL::factory()
+        $notSuppressedModelsCount = $this->faker->randomDigitNotNull();
+        $notSuppressedModels = $modelClass::factory()
             ->count($notSuppressedModelsCount)
             ->notSuppressed()
             ->notExpired()
             ->started()
             ->create();
 
-        $returnedSubscriptions = self::MODEL::withoutSuppressed()->get();
+        $returnedSubscriptions = $modelClass::withoutSuppressed()->get();
 
         $this->assertEqualsCanonicalizing(
             $notSuppressedModels->pluck('id')->toArray(),
@@ -68,16 +84,18 @@ class SuppressingScopeTest extends TestCase
 
     public function testSuppressedModelsAreReturnedWhenCallingMethodWithNotSuppressed()
     {
-        $suppressedModelsCount = $this->faker()->randomDigitNotNull();
-        $suppressedModels = self::MODEL::factory()
+        $modelClass = $this->getModelClass();
+        $suppressedModelsCount = $this->faker->randomDigitNotNull();
+
+        $suppressedModels = $modelClass::factory()
             ->count($suppressedModelsCount)
             ->suppressed()
             ->notExpired()
             ->started()
             ->create();
 
-        $notSuppressedModelsCount = $this->faker()->randomDigitNotNull();
-        $notSuppressedModels = self::MODEL::factory()
+        $notSuppressedModelsCount = $this->faker->randomDigitNotNull();
+        $notSuppressedModels = $modelClass::factory()
             ->count($notSuppressedModelsCount)
             ->notSuppressed()
             ->notExpired()
@@ -85,8 +103,7 @@ class SuppressingScopeTest extends TestCase
             ->create();
 
         $expectedSubscriptions = $suppressedModels->concat($notSuppressedModels);
-
-        $returnedSubscriptions = self::MODEL::withSuppressed()->get();
+        $returnedSubscriptions = $modelClass::withSuppressed()->get();
 
         $this->assertEqualsCanonicalizing(
             $expectedSubscriptions->pluck('id')->toArray(),
@@ -96,23 +113,25 @@ class SuppressingScopeTest extends TestCase
 
     public function testSuppressedModelsAreReturnedWhenCallingMethodWithNotSuppressedAndPassingAFalse()
     {
-        $suppressedModelsCount = $this->faker()->randomDigitNotNull();
-        self::MODEL::factory()
+        $modelClass = $this->getModelClass();
+        $suppressedModelsCount = $this->faker->randomDigitNotNull();
+
+        $modelClass::factory()
             ->count($suppressedModelsCount)
             ->suppressed()
             ->notExpired()
             ->started()
             ->create();
 
-        $notSuppressedModelsCount = $this->faker()->randomDigitNotNull();
-        $notSuppressedModels = self::MODEL::factory()
+        $notSuppressedModelsCount = $this->faker->randomDigitNotNull();
+        $notSuppressedModels = $modelClass::factory()
             ->count($notSuppressedModelsCount)
             ->notSuppressed()
             ->notExpired()
             ->started()
             ->create();
 
-        $returnedSubscriptions = self::MODEL::withSuppressed(false)->get();
+        $returnedSubscriptions = $modelClass::withSuppressed(false)->get();
 
         $this->assertEqualsCanonicalizing(
             $notSuppressedModels->pluck('id')->toArray(),
@@ -122,23 +141,26 @@ class SuppressingScopeTest extends TestCase
 
     public function testOnlySuppressedModelsAreReturnedWhenCallingMethodOnlyNotSuppressed()
     {
-        $suppressedModelsCount = $this->faker()->randomDigitNotNull();
-        $suppressedModels = self::MODEL::factory()
+        $modelClass = $this->getModelClass();
+        $suppressedModelsCount = $this->faker->randomDigitNotNull();
+
+        $suppressedModels = $modelClass::factory()
             ->count($suppressedModelsCount)
             ->suppressed()
             ->notExpired()
             ->started()
             ->create();
 
-        $notSuppressedModelsCount = $this->faker()->randomDigitNotNull();
-        self::MODEL::factory()
+        $notSuppressedModelsCount = $this->faker->randomDigitNotNull();
+
+        $modelClass::factory()
             ->count($notSuppressedModelsCount)
             ->notSuppressed()
             ->notExpired()
             ->started()
             ->create();
 
-        $returnedSubscriptions = self::MODEL::onlySuppressed()->get();
+        $returnedSubscriptions = $modelClass::onlySuppressed()->get();
 
         $this->assertEqualsCanonicalizing(
             $suppressedModels->pluck('id')->toArray(),


### PR DESCRIPTION
## Description

Replaces direct model class dependencies with configurable model bindings to improve flexibility and maintainability. Now, model classes can be swapped out via configuration without modifying the core code.

---

## Key Changes

- **Replaces hardcoded model class references with config lookups**
- **Adds validation for model instance types**
- **Updates tests to use configured model classes**
- **Maintains backward compatibility with existing model structure**

This improves package extensibility by allowing users to override default models through configuration rather than inheritance.

---

## Use Case & Background

In certain scenarios—such as in a multi-tenant application—I needed to override the model’s default connection. Despite having already overridden the default models in the `soulbscription.php` config, unexpected exceptions occurred when some parts of the code still referenced the original model classes directly rather than the user-configured ones.

For example, using `$subscriber->subscription->plan` or other relationships worked fine because those models were loaded correctly from the custom config. However, methods like `$subscriber->getFeaturesAttribute()` triggered exceptions by referencing `LucasDotVin\Soulbscription\Models\Feature` instead of the custom `App\Models\Feature`. This caused queries against the wrong database connection, resulting in "table not found" errors in my tenant database.

By replacing all direct references with configurable bindings, this PR ensures that every part of the package consistently respects the models defined in the `soulbscription.php` config, eliminating the need to modify core code for custom requirements.

---

## Screenshots & Illustrations

### Example of Configured Model Override

![image](https://github.com/user-attachments/assets/8ddf72c1-1ea7-41b5-a867-d642defac027)

#### Override the Default Connection
![image](https://github.com/user-attachments/assets/3a4337c0-3866-4f48-9993-55023ca23b24)

### Showcase Example

Using `$subscriber->subscription->plan` or any relation works correctly, because the relation loads the models from the custom `soulbscription.php` config:

![image](https://github.com/user-attachments/assets/6d3fd731-6749-4d4a-880f-34ced0e3539f)

However, calling `$subscriber->getFeaturesAttribute()` triggers an exception that the features table is not found in the tenant database (which is correct, as it resides in the main app database). The root issue is that `getFeaturesAttribute()` calls `loadTicketFeatures()`, which references `LucasDotVin\Soulbscription\Models\Feature` instead of the custom `App\Models\Feature`.

![image](https://github.com/user-attachments/assets/e03fc78d-cb21-4ebb-8a8c-b4a0c82d2172)

![image](https://github.com/user-attachments/assets/e85b6d24-7161-4dd1-a0b8-36b848dae508)

Consequently, these errors appear in any method that doesn’t pull the models from the `soulbscription.php` config.

---

## Conclusion

This PR ensures that all references to model classes within the package are resolved using the configurable bindings defined by the user. It significantly enhances maintainability and extensibility, allowing developers to override database connections or other model properties in a single location without modifying or forking the package’s internal code.

**Thank you for reviewing!** 
