### PR TITLE
[Hotfix] Renewed expiration delta bug

### DIFF
--- a/src/Enums/PeriodicityType.php
+++ b/src/Enums/PeriodicityType.php
@@ -17,10 +17,17 @@ class PeriodicityType
 
     public static function getDateDifference(Carbon $from, Carbon $to, string $unit): int
     {
+        if ($from->isAfter($to)) {
+            $delta = -1;
+        } else {
+            $delta = 1;
+        }
+
         $unitInPlural = Str::plural($unit);
 
         $differenceMethodName = 'diffIn' . $unitInPlural;
+        $difference = abs($from->{$differenceMethodName}($to));
 
-        return $from->{$differenceMethodName}($to);
+        return $difference * $delta;
     }
 }

--- a/src/Models/Concerns/HandlesRecurrence.php
+++ b/src/Models/Concerns/HandlesRecurrence.php
@@ -17,7 +17,11 @@ trait HandlesRecurrence
             $start = Carbon::parse($start);
         }
 
-        $recurrences = PeriodicityType::getDateDifference(from: $start, to: now(), unit: $this->periodicity_type);
+        $recurrences = max(
+            PeriodicityType::getDateDifference(from: $start, to: now(), unit: $this->periodicity_type),
+            0,
+        );
+
         $expirationDate = $start->copy()->add($this->periodicity_type, $this->periodicity + $recurrences);
 
         return $expirationDate;

--- a/src/Models/Concerns/HandlesRecurrence.php
+++ b/src/Models/Concerns/HandlesRecurrence.php
@@ -17,7 +17,7 @@ trait HandlesRecurrence
             $start = Carbon::parse($start);
         }
 
-        $recurrences = PeriodicityType::getDateDifference(from: now(), to: $start, unit: $this->periodicity_type);
+        $recurrences = PeriodicityType::getDateDifference(from: $start, to: now(), unit: $this->periodicity_type);
         $expirationDate = $start->copy()->add($this->periodicity_type, $this->periodicity + $recurrences);
 
         return $expirationDate;

--- a/tests/Models/Concerns/HandlesRecurrenceTest.php
+++ b/tests/Models/Concerns/HandlesRecurrenceTest.php
@@ -100,4 +100,60 @@ class HandlesRecurrenceTest extends TestCase
             $plan->calculateNextRecurrenceEnd($start->toDateTimeString()),
         );
     }
+
+    public function testModelCalculateExpirationWithRenewalAfterOneMonth()
+    {
+        Carbon::setTestNow('2021-02-18');
+
+        $plan = self::MODEL::factory()->create([
+            'periodicity_type' => PeriodicityType::Month,
+            'periodicity' => 1,
+        ]);
+
+        $start = '2021-02-20';
+
+        $this->assertEquals('2021-03-20', $plan->calculateNextRecurrenceEnd($start)->toDateString());
+    }
+
+    public function testModelCalculateExpirationWithTwoRenewalsInOneMonth()
+    {
+        Carbon::setTestNow('2021-02-19');
+
+        $plan = self::MODEL::factory()->create([
+            'periodicity_type' => PeriodicityType::Month,
+            'periodicity' => 1,
+        ]);
+
+        $start = '2021-03-20';
+
+        $this->assertEquals('2021-04-20', $plan->calculateNextRecurrenceEnd($start)->toDateString());
+    }
+
+    public function testModelCalculateExpirationWithThreeRenewalsInOneMonth()
+    {
+        Carbon::setTestNow('2021-02-20');
+
+        $plan = self::MODEL::factory()->create([
+            'periodicity_type' => PeriodicityType::Month,
+            'periodicity' => 1,
+        ]);
+
+        $start = '2021-04-20';
+
+        $this->assertEquals('2021-05-20', $plan->calculateNextRecurrenceEnd($start)->toDateString());
+    }
+
+    public function testModelCalculateExpirationWithRenewalAfterExpiration()
+    {
+        Carbon::setTestNow('2021-02-21');
+
+        $plan = self::MODEL::factory()->create([
+            'periodicity_type' => PeriodicityType::Month,
+            'periodicity' => 1,
+        ]);
+
+        $start = '2021-02-20';
+
+        $this->assertEquals('2021-03-20', $plan->calculateNextRecurrenceEnd($start)->toDateString());
+    }
 }


### PR DESCRIPTION
This pull request includes changes to improve the handling of date differences and recurrence calculations in the `PeriodicityType` and `HandlesRecurrence` classes. Additionally, new test cases have been added to ensure the correctness of these calculations.

Improvements to date difference calculation:

* [`src/Enums/PeriodicityType.php`](diffhunk://#diff-26c2eaaf012c09da4b35f5c8a86cc25dae1160bbfa16b6920ea9f3959f7f4af8R20-R31): Modified the `getDateDifference` method to handle cases where the start date is after the end date, ensuring the difference is always positive and adjusting the result based on the order of the dates.

Enhancements to recurrence calculation:

* [`src/Models/Concerns/HandlesRecurrence.php`](diffhunk://#diff-19fc42b13de73ffb26b3f81423034d865ea20825f076362e80842c32e20b663dL20-R24): Updated the `calculateNextRecurrenceEnd` method to use the modified `getDateDifference` method and ensure the number of recurrences is non-negative.

Addition of new test cases:

* [`tests/Models/Concerns/HandlesRecurrenceTest.php`](diffhunk://#diff-c856dd03abc5e3f2b23435021ec638a9b8b454c943b34e0ac366f97510522a48R103-R158): Added multiple test cases to verify the correct calculation of the next recurrence end date under various scenarios, including renewals after one month, multiple renewals within a month, and renewals after expiration.