### PR TITLE
[Feature] Laravel 12 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,6 +32,8 @@ jobs:
           - laravel: 12.*
             testbench: ^10.0
         exclude:
+          - laravel: 9.*
+            php: 8.3
           - laravel: 11.*
             php: 8.1
           - laravel: 12.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,25 +3,35 @@ name: run-tests
 on:
   workflow_dispatch:
   push:
-    branches: [main, develop]
+    branches:
+      - main
+      - develop
   pull_request:
-    branches: [main, develop]
+    branches:
+      - main
+      - develop
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
         php: [8.1, 8.2]
-        laravel: [9.*, 10.*]
+        laravel: ['9.*', '10.*', '11.*']
         stability: [prefer-stable]
         include:
           - laravel: 9.*
             testbench: ^7.10
           - laravel: 10.*
             testbench: ^8.0
+          - laravel: 11.*
+            testbench: ^9.0
+        exclude:
+          - laravel: 11.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -50,6 +60,4 @@ jobs:
         run: vendor/bin/phpunit
 
       - name: Codecov
-        # You may pin to the exact commit or the version.
-        # uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
         uses: codecov/codecov-action@v3.1.4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1, 8.2]
-        laravel: ['9.*', '10.*', '11.*']
+        php: [8.1, 8.2, 8.3]
+        laravel: ['9.*', '10.*', '11.*', '12.*']
         stability: [prefer-stable]
         include:
           - laravel: 9.*
@@ -29,8 +29,12 @@ jobs:
             testbench: ^8.0
           - laravel: 11.*
             testbench: ^9.0
+          - laravel: 12.*
+            testbench: ^10.0
         exclude:
           - laravel: 11.*
+            php: 8.1
+          - laravel: 12.*
             php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     ],
     "require": {
         "php": "^8.0|^8.1|^8.2",
-        "illuminate/contracts": "^8.0|^9.0|^10.0"
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.22|^7.0|^8.0",
+        "orchestra/testbench": "^6.22|^7.0|^8.0|^9.0",
         "phpunit/phpunit": "^9.5|^10.0",
         "squizlabs/php_codesniffer": "*"
     },
@@ -52,7 +52,7 @@
             "providers": [
                 "LucasDotVin\\Soulbscription\\SoulbscriptionServiceProvider"
             ],
-            "aliases": {}
+            "aliases": []
         }
     },
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
     ],
     "require": {
         "php": "^8.0|^8.1|^8.2",
-        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0"
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.22|^7.0|^8.0|^9.0",
-        "phpunit/phpunit": "^9.5|^10.0",
+        "orchestra/testbench": "^6.22|^7.0|^8.0|^9.0|^10.0",
+        "phpunit/phpunit": "^9.5|^10.0|^11.5.3",
         "squizlabs/php_codesniffer": "*"
     },
     "autoload": {

--- a/database/migrations/2022_02_01_233701_create_plans_table.php
+++ b/database/migrations/2022_02_01_233701_create_plans_table.php
@@ -16,7 +16,7 @@ return new class extends Migration {
             $table->id();
             $table->integer('grace_days')->default(0);
             $table->string('name');
-            $table->unsignedInteger('periodicity')->nullable();
+            $table->integer('periodicity')->unsigned()->nullable();
             $table->string('periodicity_type')->nullable();
             $table->softDeletes();
             $table->timestamps();

--- a/database/migrations/2022_02_01_235540_create_features_table.php
+++ b/database/migrations/2022_02_01_235540_create_features_table.php
@@ -18,7 +18,7 @@ return new class() extends Migration {
             $table->boolean('consumable');
             $table->boolean('quota')->default(false);
             $table->boolean('postpaid')->default(false);
-            $table->unsignedInteger('periodicity')->nullable();
+            $table->integer('periodicity')->unsigned()->nullable();
             $table->string('periodicity_type')->nullable();
             $table->softDeletes();
             $table->timestamps();

--- a/database/migrations/2022_02_02_000527_create_feature_consumptions_table.php
+++ b/database/migrations/2022_02_02_000527_create_feature_consumptions_table.php
@@ -14,7 +14,7 @@ return new class() extends Migration {
     {
         Schema::create('feature_consumptions', function (Blueprint $table) {
             $table->id();
-            $table->unsignedDecimal('consumption')->nullable();
+            $table->decimal('consumption')->unsigned()->nullable();
             $table->timestamp('expired_at')->nullable();
             $table->foreignIdFor(\LucasDotVin\Soulbscription\Models\Feature::class)->constrained()->cascadeOnDelete();
             $table->timestamps();


### PR DESCRIPTION
This pull request includes updates to the testing workflow and dependencies to support newer versions of PHP and Laravel. The most important changes include updating the GitHub Actions workflow configuration and modifying the `composer.json` file to include new versions of dependencies.

Updates to GitHub Actions workflow:

* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L6-R38): Updated the `branches` configuration to use a list format and added support for PHP 8.3 and Laravel versions 11.* and 12.*. Also, excluded certain PHP and Laravel version combinations from the matrix.
* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L53-L54): Updated the Codecov action to use version `v3.1.4`.

Updates to dependencies:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L21-R25): Added support for `illuminate/contracts` versions 11.0 and 12.0.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L21-R25): Added support for `orchestra/testbench` versions 9.0 and 10.0, and `phpunit/phpunit` version 11.5.3.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L55-R55): Changed the `aliases` configuration to use an empty array instead of an empty object.