### PR TITLE
[Feature] Improvements for subscriptions with no expiration

### DIFF
--- a/src/Models/Concerns/HasSubscriptions.php
+++ b/src/Models/Concerns/HasSubscriptions.php
@@ -121,14 +121,13 @@ trait HasSubscriptions
     {
         if ($plan->periodicity) {
             $expiration = $expiration ?? $plan->calculateNextRecurrenceEnd($startDate);
+        } else {
+            $expiration = $expiration ?? null;
+        }
 
-            $graceDaysEnd = $plan->hasGraceDays
+        $graceDaysEnd = $plan->hasGraceDays && $expiration
                 ? $plan->calculateGraceDaysEnd($expiration)
                 : null;
-        } else {
-            $expiration = null;
-            $graceDaysEnd = null;
-        }
 
         return $this->subscription()
             ->make([

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -157,6 +157,10 @@ class Subscription extends Model
                 and $this->grace_days_ended_at->isPast();
         }
 
+        if (! $this->expired_at) {
+            return false;
+        }
+
         return $this->expired_at->isPast();
     }
 

--- a/tests/Models/Concerns/HasSubscriptionsTest.php
+++ b/tests/Models/Concerns/HasSubscriptionsTest.php
@@ -1077,6 +1077,21 @@ class HasSubscriptionsTest extends TestCase
         $this->assertNull($subscription->expired_at);
     }
 
+    public function testItUsesReceivedExpirationEvenIfThePlanHasNoPeriodicity()
+    {
+        $plan = Plan::factory()->createOne([
+            'periodicity' => null,
+        ]);
+
+        $subscriber = User::factory()->createOne();
+        $subscription = $subscriber->subscribeTo($plan, now()->addDay());
+
+        $this->assertDatabaseHas('subscriptions', [
+            'id' => $subscription->id,
+            'expired_at' => now()->addDay(),
+        ]);
+    }
+
     public function testItReturnsZeroForCurrentConsumptionWhenSubscriberDoesNotHaveFeature()
     {
         $feature = Feature::factory()->createOne();

--- a/tests/Models/SubscriptionTest.php
+++ b/tests/Models/SubscriptionTest.php
@@ -201,6 +201,24 @@ class SubscriptionTest extends TestCase
         ]);
     }
 
+    public function testModelDoesNotRegisterOverdueIfThereIsNoExpiration()
+    {
+        $subscriber = User::factory()->create();
+        $subscription = Subscription::factory()
+            ->for($subscriber, 'subscriber')
+            ->create([
+                'expired_at' => null,
+            ]);
+
+        $subscription->renew();
+
+        $this->assertDatabaseCount('subscription_renewals', 1);
+        $this->assertDatabaseHas('subscription_renewals', [
+            'subscription_id' => $subscription->id,
+            'overdue' => false,
+        ]);
+    }
+
     public function testModelConsidersGraceDaysOnOverdue()
     {
         $subscriber = User::factory()->create();


### PR DESCRIPTION
This pull request refines subscription handling by improving the logic for expiration and overdue status, and adds corresponding test cases to ensure correctness. The key changes include adjustments to how expiration dates are determined, handling of overdue status, and new tests to validate these behaviors.

### Subscription expiration logic improvements:
* Updated `subscribeTo` method in `HasSubscriptions.php` to set expiration to `null` explicitly if the plan lacks periodicity, and adjusted grace days calculation to account for the absence of expiration.

### Overdue status handling:
* Modified `getIsOverdueAttribute` in `Subscription.php` to return `false` if the subscription has no expiration date, ensuring overdue logic is only applied when relevant.

### New test cases:
* Added `testItUsesReceivedExpirationEvenIfThePlanHasNoPeriodicity` in `HasSubscriptionsTest.php` to verify that an explicitly provided expiration date is respected even when the plan lacks periodicity.
* Added `testModelDoesNotRegisterOverdueIfThereIsNoExpiration` in `SubscriptionTest.php` to confirm that overdue status is not marked if the subscription has no expiration date.