### PR TITLE
[Release] Improvements to the handling of subscriptions with no expiration

### DIFF
--- a/src/Models/Concerns/HasSubscriptions.php
+++ b/src/Models/Concerns/HasSubscriptions.php
@@ -121,14 +121,13 @@ trait HasSubscriptions
     {
         if ($plan->periodicity) {
             $expiration = $expiration ?? $plan->calculateNextRecurrenceEnd($startDate);
+        } else {
+            $expiration = $expiration ?? null;
+        }
 
-            $graceDaysEnd = $plan->hasGraceDays
+        $graceDaysEnd = $plan->hasGraceDays && $expiration
                 ? $plan->calculateGraceDaysEnd($expiration)
                 : null;
-        } else {
-            $expiration = null;
-            $graceDaysEnd = null;
-        }
 
         return $this->subscription()
             ->make([

--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -157,6 +157,10 @@ class Subscription extends Model
                 and $this->grace_days_ended_at->isPast();
         }
 
+        if (! $this->expired_at) {
+            return false;
+        }
+
         return $this->expired_at->isPast();
     }
 

--- a/tests/Models/Concerns/HasSubscriptionsTest.php
+++ b/tests/Models/Concerns/HasSubscriptionsTest.php
@@ -1077,6 +1077,21 @@ class HasSubscriptionsTest extends TestCase
         $this->assertNull($subscription->expired_at);
     }
 
+    public function testItUsesReceivedExpirationEvenIfThePlanHasNoPeriodicity()
+    {
+        $plan = Plan::factory()->createOne([
+            'periodicity' => null,
+        ]);
+
+        $subscriber = User::factory()->createOne();
+        $subscription = $subscriber->subscribeTo($plan, now()->addDay());
+
+        $this->assertDatabaseHas('subscriptions', [
+            'id' => $subscription->id,
+            'expired_at' => now()->addDay(),
+        ]);
+    }
+
     public function testItReturnsZeroForCurrentConsumptionWhenSubscriberDoesNotHaveFeature()
     {
         $feature = Feature::factory()->createOne();

--- a/tests/Models/SubscriptionTest.php
+++ b/tests/Models/SubscriptionTest.php
@@ -201,6 +201,24 @@ class SubscriptionTest extends TestCase
         ]);
     }
 
+    public function testModelDoesNotRegisterOverdueIfThereIsNoExpiration()
+    {
+        $subscriber = User::factory()->create();
+        $subscription = Subscription::factory()
+            ->for($subscriber, 'subscriber')
+            ->create([
+                'expired_at' => null,
+            ]);
+
+        $subscription->renew();
+
+        $this->assertDatabaseCount('subscription_renewals', 1);
+        $this->assertDatabaseHas('subscription_renewals', [
+            'subscription_id' => $subscription->id,
+            'overdue' => false,
+        ]);
+    }
+
     public function testModelConsidersGraceDaysOnOverdue()
     {
         $subscriber = User::factory()->create();


### PR DESCRIPTION
This pull request introduces changes to improve subscription handling logic and ensure proper test coverage for edge cases. The most important updates include refining the expiration logic for plans without periodicity, adjusting overdue determination, and adding new test cases to validate these behaviors.

### Subscription logic improvements:
* Updated `subscribeTo` method in `HasSubscriptions` to handle plans without periodicity by explicitly setting expiration to `null` when not provided. This ensures consistent behavior. (`src/Models/Concerns/HasSubscriptions.php`, [src/Models/Concerns/HasSubscriptions.phpR124-L131](diffhunk://#diff-ac6886ddcd0120d0d42e4ec94e563efe920724ace3c28aaa7045df98093dad37R124-L131))
* Modified `getIsOverdueAttribute` in `Subscription` to return `false` if `expired_at` is `null`, preventing overdue status for subscriptions without an expiration date. (`src/Models/Subscription.php`, [src/Models/Subscription.phpR160-R163](diffhunk://#diff-1f905070617e0645594ec681f9787bc7fd494c582ca51a1c27011d56cf2fb0d6R160-R163))

### Test coverage enhancements:
* Added `testItUsesReceivedExpirationEvenIfThePlanHasNoPeriodicity` to verify that a provided expiration date is respected even when the plan lacks periodicity. (`tests/Models/Concerns/HasSubscriptionsTest.php`, [tests/Models/Concerns/HasSubscriptionsTest.phpR1080-R1094](diffhunk://#diff-067491ff33c57937244189d9b9f444b4af3a836c1f746f462f77a44e933143a9R1080-R1094))
* Introduced `testModelDoesNotRegisterOverdueIfThereIsNoExpiration` to confirm that subscriptions without an expiration date do not register as overdue during renewal. (`tests/Models/SubscriptionTest.php`, [tests/Models/SubscriptionTest.phpR204-R221](diffhunk://#diff-5bd1c46cb39588cc667b4f6e5733f9eabd8c54721f10cda94752f6ec4f7c5b25R204-R221))