### PR TITLE
[Hotfix] Renewing subscriptions from plans with no periodicity

### DIFF
--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -170,6 +170,10 @@ class Subscription extends Model
             return $expirationDate;
         }
 
+        if (empty($this->plan->periodicity)) {
+            return null;
+        }
+
         if ($this->isOverdue) {
             return $this->plan->calculateNextRecurrenceEnd();
         }


### PR DESCRIPTION
This pull request addresses a potential edge case in subscription renewal logic and ensures proper testing for scenarios where a subscription plan lacks periodicity. The most important changes include adding a safeguard in the renewal logic and introducing a new test to validate this behavior.

### Subscription renewal logic improvements:
* [`src/Models/Subscription.php`](diffhunk://#diff-1f905070617e0645594ec681f9787bc7fd494c582ca51a1c27011d56cf2fb0d6R173-R176): Updated the `getRenewedExpiration` method to return `null` if the subscription plan's periodicity is not defined, preventing potential errors during renewal.

### Test coverage enhancements:
* [`tests/Models/SubscriptionTest.php`](diffhunk://#diff-5bd1c46cb39588cc667b4f6e5733f9eabd8c54721f10cda94752f6ec4f7c5b25R222-R249): Added a new test, `testModelRenewsEvenIfPlanHasNoPeriodicity`, to verify that the subscription can still renew and dispatch the `SubscriptionRenewed` event even when the plan lacks periodicity. This ensures the database reflects the renewal accurately.