### PR TITLE
[Hotfix] Preset expiration in renewals for plans with no periodicity

### DIFF
--- a/src/Models/Subscription.php
+++ b/src/Models/Subscription.php
@@ -112,7 +112,7 @@ class Subscription extends Model
         $expirationDate = $this->getRenewedExpiration($expirationDate);
         $graceDaysEndedAt = null;
 
-        if ($this->plan->grace_days) {
+        if ($this->plan->grace_days && $expirationDate) {
             $graceDaysEndedAt = $expirationDate->copy()->addDays($this->plan->grace_days);
         }
 


### PR DESCRIPTION
This pull request introduces a fix to the `renew` method in the `Subscription` model to handle cases where the `expirationDate` is null, and adds new test cases to ensure the behavior is correctly validated. The changes improve the robustness of subscription renewal logic, particularly for plans with grace days but no periodicity.

### Fix to subscription renewal logic:

* [`src/Models/Subscription.php`](diffhunk://#diff-1f905070617e0645594ec681f9787bc7fd494c582ca51a1c27011d56cf2fb0d6L115-R115): Updated the `renew` method to include a conditional check ensuring that grace days are only calculated if an `expirationDate` is provided. This prevents potential errors when the `expirationDate` is null.

### New test cases for subscription renewal:

* `tests/Models/SubscriptionTest.php`: Added two new test cases:
  - [`testModelRenewsEvenIfPlanHasNoPeriodicityButHasGraceDays`](diffhunk://#diff-5bd1c46cb39588cc667b4f6e5733f9eabd8c54721f10cda94752f6ec4f7c5b25R250-R309): Verifies that a subscription can renew even if the plan lacks periodicity but includes grace days.
  - [`testModelRenewsWithDefinedExpirationEvenIfPlanHasNoPeriodicityButHasGraceDays`](diffhunk://#diff-5bd1c46cb39588cc667b4f6e5733f9eabd8c54721f10cda94752f6ec4f7c5b25R250-R309): Ensures that a subscription renews correctly with a defined expiration date, calculating the `grace_days_ended_at` field as expected.